### PR TITLE
Fix coffee target to not munge files with two periods in them

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
                 cwd: 'coffee/',
                 src: '**/**/**/**/*.coffee',
                 dest: 'build',
-                ext: '.js'
+                rename: function(dest, src){ return dest + '/' + src.replace('.coffee', '.js') },
             }
         },
 


### PR DESCRIPTION
cilantro.ui.coffee was being written to cilantro.js because grunt considers extensions to always begin at the first period in a file name.
