### PR TITLE
Do not cache fetch results for collections

### DIFF
--- a/coffee/cilantro/models/base.coffee
+++ b/coffee/cilantro/models/base.coffee
@@ -28,10 +28,9 @@ define [
             @links = {}
             super(attrs, options)
 
-        fetch: (options) ->
-            options = options or {}
-            options.cache = false
-            return c.Backbone.Collection.prototype.fetch.call(this, options)
+        fetch: (options={}) ->
+            options.cache ?= false
+            super(options)
 
         parse: (attrs, options) ->
             if attrs? and attrs._links?


### PR DESCRIPTION
IE refuses to cooperate and work like other browsers. Despite the data
changing on the server, IE will use cached results of earlier fetch
calls when updating a collection. To avoid this, this commit completely
blocks all caching on fetch calls for collections.

This should resolve issue https://github.com/cbmi/cilantro/issues/142.
