### PR TITLE
Fix case where clicking non-routeable link broke back button

### DIFF
--- a/coffee/cilantro.ui.coffee
+++ b/coffee/cilantro.ui.coffee
@@ -44,7 +44,7 @@ define [
             # If this is a valid route then go ahead and navigate to it, 
             # otherwise let the event process normally to load the new 
             # location.
-            if c.router.isRoute(pathname) 
+            if c.router.hasRoute(pathname) 
                 event.preventDefault()
                 Backbone.history.navigate(pathname, trigger: true)
 

--- a/coffee/cilantro/router.coffee
+++ b/coffee/cilantro/router.coffee
@@ -92,7 +92,7 @@ define [
 
         # Returns true if the supplied route is in the list of routes known
         # to this router and false if it isn't known to this router.
-        isRoute: (route) ->
+        hasRoute: (route) ->
             return @_routes.hasOwnProperty(route) 
 
         # Attempt to get the corresponding config if one exists and use


### PR DESCRIPTION
For whatever reason, using Backbone.history.navigate to check if a route exists then calling preventDefault() was preventing a valid entry from being written to the browser's history. Using a separate method for checking for route existence then following the preventDefault and navigate steps resolves the problem. I have tested and this is no longer an issue in FF, IE, Chrome, or Safari.
