### PR TITLE
Fix faulty URL query string in base Page model

### DIFF
--- a/src/coffee/cilantro/models/paginator.coffee
+++ b/src/coffee/cilantro/models/paginator.coffee
@@ -120,8 +120,7 @@ define [
         idAttribute: 'page_num'
 
         url: ->
-            "#{ @collection.url() }?page=#{ @id }&per_page=#{ @collection.perPage }"
-
+            c.utils.alterUrlParams(@collection.url(), 'page', @id, 'per_page', @collection.perPage)
 
 
     # Paginator collection for managing it's pages

--- a/src/coffee/cilantro/session.coffee
+++ b/src/coffee/cilantro/session.coffee
@@ -1,22 +1,16 @@
 define [
     'jquery',
     'mediator'
+    './utils'
     './session/channels'
-], ($, mediator, channels) ->
-
-    # Utility for parsing links
-    linkParser = (href) ->
-        parser = document.createElement('a')
-        parser.href = href
-        return parser
-
+], ($, mediator, utils, channels) ->
 
     # Get a URL by name for the current session relative to some hostname
     getSessionUrl = (session, key) ->
         if not session? then return
         if not (link = session.urls[key]) then return
-        current = linkParser(session.root)
-        target = linkParser(link.href)
+        current = utils.linkParser(session.root)
+        target = utils.linkParser(link.href)
         current.pathname = target.pathname
         return current.href
 

--- a/src/coffee/cilantro/utils.coffee
+++ b/src/coffee/cilantro/utils.coffee
@@ -1,6 +1,7 @@
 define [
     'underscore'
     './utils/numbers'
+    './utils/url'
 ], (_, mods...) ->
 
     # Convenience method for getting a value using the dot-notion for

--- a/src/coffee/cilantro/utils/url.coffee
+++ b/src/coffee/cilantro/utils/url.coffee
@@ -1,0 +1,46 @@
+define ->
+
+    # Utility for parsing links
+    # http://stackoverflow.com/a/6644749/407954
+    # https://developer.mozilla.org/en-US/docs/Web/API/window.location
+    linkParser = (href) ->
+        a = document.createElement('a')
+        a.href = href
+        return a
+
+
+    # Augments/changes a URL's query parameters. Takes a URL and a variable
+    # number of param pairs.
+    alterUrlParams = (href, args...) ->
+        a = linkParser(href)
+
+        # Keep the order of the keys
+        keys = []
+        params = {}
+
+        for s in a.search.substr(1).split('&')
+            [k, v] = s.split('=')
+            if k
+                params[k] = v
+                keys.push(k)
+
+        # Update the params hash with parameters
+        for arg, i in args
+            if i % 2 is 0
+                p = arg
+                if not params[p]? then keys.push(p)
+            else
+                params[p] = arg
+
+        # Rebuild search params
+        search = []
+        for key in keys
+            if not (value = params[key])?
+                value = ''
+            search.push "#{ key }=#{ value }"
+
+        a.search = "?#{ search.join('&') }"
+        return a.href
+
+
+    { linkParser, alterUrlParams }


### PR DESCRIPTION
The `url` method assumed the paginator did not already have a query
string on the URL. A utility has been implemented that takes a URL and
adds or replaces query string params given a variable list of arguments.

Fix #212
