### PR TITLE
Add better handling/display when no data is returned for a filter set

### DIFF
--- a/src/coffee/cilantro/ui/tables/body.coffee
+++ b/src/coffee/cilantro/ui/tables/body.coffee
@@ -20,5 +20,9 @@ define [
                 collection: model.data
             , @options
 
+        initialize: ->
+            @on 'collection:rendered', ->
+                if @model.series.length == 0
+                    @$el.html('No data to display')
 
     { Body }

--- a/src/coffee/cilantro/ui/tables/row.coffee
+++ b/src/coffee/cilantro/ui/tables/row.coffee
@@ -1,7 +1,8 @@
 define [
     '../core'
+    '../base'
     './cell'
-], (c, cell) ->
+], (c, base, cell) ->
 
 
     class Row extends c.Marionette.CollectionView
@@ -16,14 +17,10 @@ define [
                 model: model
 
 
-    class EmptyRow extends c.Backbone.View
-        className: 'empty'
+    class EmptyRow extends base.LoadView
+        align: 'left'
 
         tagName: 'tr'
-
-        render: ->
-            @$el.html 'No data to display...'
-            return @
 
 
     { Row, EmptyRow }


### PR DESCRIPTION
This should resolve #169. While the results are being fetched, a loading indicator is displayed. When the collection is finished, either the results themselves are displayed or, if there are no results, a message telling the user there is no data is displayed.
