### PR TITLE
Correctly position table header glyphs relatively to parent span

### DIFF
--- a/src/coffee/cilantro/ui/tables/header.coffee
+++ b/src/coffee/cilantro/ui/tables/header.coffee
@@ -44,39 +44,32 @@ define [
 
         # Finds and returns the sort icon html associatied with the sort
         # direction of the Facet being represented by this header cell.
-        getSortIconHtml: ->
-            model = _.find(
-                @view.facets.models,
-                (m) -> m.get('concept') == @model.id,
-                this)
+        getSortIconClass: ->
+            model = _.find @view.facets.models, (m) =>
+                @model.id is m.get('concept')
 
             # If there are no view facets for the this header cell's model
             # then the this really shouldn't be displaying anyway so return
             # the empty string. We really should not ever get into this
             # situation since the facets should be driving the columns but
             # this check prevents TypeErrors just in case.
-            if not model?
-                return ""
+            if not model? then return
 
-            direction = (model.get('sort') || "").toLowerCase()
+            direction = (model.get('sort') or '').toLowerCase()
 
-            if direction == "asc"
-                iconClass = "icon-sort-up"
-            else if direction == "desc"
-                iconClass = "icon-sort-down"
-            else
-                iconClass = "icon-sort"
-
-            "<i class=#{ iconClass }></i>"
+            return switch direction
+                when 'asc' then 'icon-sort-up'
+                when 'desc' then 'icon-sort-down'
+                else 'icon-sort'
 
         render: ->
             @toggleVisible()
 
-            iconHtml = @getSortIconHtml()
+            iconClass = @getSortIconClass()
 
             # TODO: Could we use a template here instead and then just modify
             # the class on the icon in the template?
-            @$el.html("<span>" + @model.get('name') + iconHtml)
+            @$el.html("<span>#{ @model.get('name') } <i class=#{ iconClass }></i></span>")
 
             return @
 

--- a/src/scss/base/_stacked.scss
+++ b/src/scss/base/_stacked.scss
@@ -13,7 +13,7 @@
         position: absolute;
         left: 0;
         right: 0;
-        overflow-y: scroll;
+        overflow-y: auto;
         overflow-x: hidden;
 
         &.overlay-before {

--- a/src/scss/base/_table.scss
+++ b/src/scss/base/_table.scss
@@ -4,4 +4,30 @@ table thead th {
     &:first-child {
         border-left: 0;
     }
+
+    span {
+        position: relative;
+        display: block;
+
+        // If an icon is present, it is typically denoting the sort order
+        i {
+            position: absolute;
+            right: 5px;
+            top: 50%;
+
+            // Only about 6/13px are visible, margin is used to offset
+            // visible portion
+            &.icon-sort-up {
+                margin-top: -4px;
+            }
+
+            &.icon-sort-down {
+                margin-top: -8px;
+            }
+
+            &.icon-sort {
+                margin-top: -6px;
+            }
+        }
+    }
 }

--- a/src/scss/workflows/_results.scss
+++ b/src/scss/workflows/_results.scss
@@ -40,34 +40,12 @@
         margin-top: 20px;
         overflow-x: scroll;
 
-        thead {
-            th {
-                position: relative;
-                cursor: pointer;
+        thead th {
+            cursor: pointer;
+            min-height: 100px;
 
-                i {
-                    position: absolute;
-                    right: 5px;
-                    top: 50%;
-
-                    // Only about 6/13px are visible, margin is used to offset
-                    // visible portion
-                    &.icon-sort-up {
-                        margin-top: -4px;
-                    }
-
-                    &.icon-sort-down {
-                        margin-top: -8px;
-                    }
-
-                    &.icon-sort {
-                        margin-top: -6px;
-                    }
-                }
-
-                &:hover {
-                    background-color: #eee;
-                }
+            &:hover {
+                background-color: #eee;
             }
         }
     }


### PR DESCRIPTION
This fix also includes hiding the vertical scroll if needed and
setting a min-height for table cells.

Fix #225
