### PR TITLE
Implement notifications API

### DIFF
--- a/spec/notify.js
+++ b/spec/notify.js
@@ -1,0 +1,41 @@
+define(['cilantro/ui/notify'], function(notify) {
+
+    var stream = new notify.Notifications;
+    stream.$el.appendTo('body').css({
+        position: 'fixed',
+        right: 0,
+        top: 0
+    });
+
+    describe('Notifications', function() {
+        it('should initialize with a collection', function() {
+            expect(stream.collection).toBeDefined();
+        });
+
+        it('should create messages via notify', function() {
+            stream.notify({
+                message: 'Dismissable and Ephemeral'
+            });
+
+            stream.notify({
+                message: 'Ephemeral',
+                dismissable: false
+            });
+
+            stream.notify({
+                message: 'Dismissable',
+                timeout: 0
+            });
+
+            stream.notify({
+                message: 'Fixed',
+                timeout: 0,
+                dismissable: false
+            });
+
+            expect(stream.collection.length).toEqual(4);
+        });
+
+    });
+
+});

--- a/src/coffee/cilantro/ui.coffee
+++ b/src/coffee/cilantro/ui.coffee
@@ -17,6 +17,7 @@ define [
     './ui/query'
     './ui/workflows'
     './ui/paginator'
+    './ui/notify'
 ], ($, _, Backbone, c, router, mods...) ->
 
 

--- a/src/coffee/cilantro/ui/core.coffee
+++ b/src/coffee/cilantro/ui/core.coffee
@@ -1,5 +1,6 @@
 define [
     '../core'
+    './notify'
     'bootstrap'
     'plugins/bootstrap-datepicker'
     'plugins/jquery-ui'
@@ -9,6 +10,17 @@ define [
     'plugins/jquery-stacked'
     'plugins/typeahead'
     'plugins/typeselect'
-], (c) ->
+], (c, notify) ->
+
+    # Initialize notification stream and append it to the main element
+    stream = new notify.Notifications
+        id: 'notifications'
+
+    $(c.config.get('ui.main'))
+        .css('position', 'relative')
+        .append(stream.render().el)
+
+    # Attach primary method for creating notifications
+    c.notify = stream.notify
 
     return c

--- a/src/coffee/cilantro/ui/notify.coffee
+++ b/src/coffee/cilantro/ui/notify.coffee
@@ -1,0 +1,95 @@
+###
+The cilantro/ui/notify module provides an interface for creating notifications
+for display to users.
+###
+define [
+    'underscore'
+    'backbone'
+    'marionette'
+    'tpl!templates/notification.html'
+], (_, Backbone, Marionette, templates...) ->
+
+    templates = _.object ['notification'], templates
+
+    class NotificationModel extends Backbone.Model
+        defaults:
+            level: 'info'
+            timeout: 4000
+            dismissable: true
+            header: null
+            message: ''
+
+    class Notification extends Marionette.ItemView
+        className: 'alert'
+
+        template: templates.notification
+
+        ui:
+            dismiss: '[data-dismiss]'
+            header: 'h4'
+            message: 'div'
+
+        events:
+            'click [data-dismiss]': 'dismiss'
+            'mouseover': 'hold'
+            'mouseout': 'release'
+
+        dismiss: ->
+            # Clear the timer if set
+            clearTimeout(@_timer)
+
+        hold: ->
+            if not @_start then return
+            clearTimeout(@_timer)
+            # In case the fade out has started
+            @$el.clearQueue('fx').show()
+
+        release: ->
+            if not @_start then return
+            # Determine the time left relative to the start time
+            end = @_start + @model.get('timeout')
+            # Release after one second in case the mouse runs away
+            timeout = Math.max(end - (new Date()).getTime(), 1000)
+            @_timer = setTimeout =>
+                @$el.fadeOut()
+            , timeout
+
+        onRender: ->
+            # Info is the default so the empty string and null will
+            # use the info class. Warning does not require a class
+            # (this uses Bootstrap's alert classes).
+            levelClass = switch (level = @model.get('level'))
+                when '', null then 'alert-info'
+                when 'warning' then ''
+                else "alert-#{ level }"
+
+            # Add class for the level. Supported levels include 'info',
+            # 'success', 'error' and 'warning'
+            @$el.addClass(levelClass)
+
+            # Toggle header if falsy
+            @ui.header.hide(!!@model.get('header'))
+
+            # Toggle dismiss button
+            @ui.dismiss.toggle(@model.get('dismissable'))
+
+            # Add a timeout
+            if (timeout = @model.get('timeout'))
+                @_start = (new Date()).getTime()
+                @release()
+
+    class Notifications extends Marionette.CollectionView
+        className: 'notifications'
+
+        itemView: Notification
+
+        constructor: (options={}) ->
+            options.collection ?= new Backbone.Collection
+            super(options)
+
+        notify: (attrs) =>
+            model = new NotificationModel(attrs)
+            @collection.add(model)
+            @children.findByModel(model)
+
+    { Notifications, Notification }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -45,5 +45,7 @@
 
 @import "views/exporter";
 
+@import "views/notify";
+
 @import "workflows/query";
 @import "workflows/results";

--- a/src/scss/views/_notify.scss
+++ b/src/scss/views/_notify.scss
@@ -1,0 +1,16 @@
+.notifications {
+    z-index: 2000;
+    position: absolute;
+    top: 0;
+    right: 0;
+    max-width: 400px;
+    min-width: 200px;
+    width: 20%;
+}
+
+#notifications {
+    position: fixed;
+    // Offset relative to document
+    right: 10px;
+    top: 10px;
+}

--- a/src/templates/notification.html
+++ b/src/templates/notification.html
@@ -1,0 +1,3 @@
+<button class="close" data-dismiss="alert">&times;</button>
+<h4><%= data.header %></h4>
+<div><%= data.message %></div>


### PR DESCRIPTION
This introduces the cilantro/ui/notify module which exposes the
structures for creating a notifications stream.

The default _global_ stream is defined in the cilantro/ui/core module
and attaches the `notify` method directly on the cilantro object. Other
modules can reference it via `c.notify(options)`

Fix #227
