### PR TITLE
Changes offset calculation to use offset() instead of position() 

### DIFF
--- a/src/coffee/cilantro/ui/workflows/results.coffee
+++ b/src/coffee/cilantro/ui/workflows/results.coffee
@@ -106,7 +106,7 @@ define [
 
             # Find the bounds of the results workflow to properly fix the
             # position of the context/filter panel.
-            @workflowTopOffset = @$el.position().top
+            @workflowTopOffset = @$el.offset().top
             @workflowRightOffset = window.innerWidth - (@$el.position().left + @$el.width())
 
             @ui.contextContainer.css('top', @workflowTopOffset)


### PR DESCRIPTION
Fixes #239. Please note that there is still some offset issues on the "Refine Query" button on the bottom of the filter  not caused by this update but related. I'll file a separate issue. 
