### PR TITLE
Header icon template changed to avoid overlap. Fixes #243

### DIFF
--- a/src/coffee/cilantro/ui/tables/header.coffee
+++ b/src/coffee/cilantro/ui/tables/header.coffee
@@ -69,7 +69,8 @@ define [
 
             # TODO: Could we use a template here instead and then just modify
             # the class on the icon in the template?
-            @$el.html("<span style='float:left'>#{ @model.get('name') }</span><i style='float:right' class=#{ iconClass }></i></span>")
+            @$el.attr('title',@model.get('name'))
+            @$el.html("#{ @model.get('name') }<i class=#{ iconClass }></i>")
 
             return @
 

--- a/src/scss/base/_table.scss
+++ b/src/scss/base/_table.scss
@@ -1,6 +1,7 @@
 table thead th {
     border-left: 1px solid #ddd;
-
+    table-layout: fixed;
+    
     &:first-child {
         border-left: 0;
     }

--- a/src/scss/workflows/_results.scss
+++ b/src/scss/workflows/_results.scss
@@ -39,11 +39,15 @@
     .table-region {
         margin-top: 20px;
         overflow-x: scroll;
-
+        
         thead th {
             cursor: pointer;
             min-height: 100px;
-
+            display:block;
+            width: 0%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
             &:hover {
                 background-color: #eee;
             }


### PR DESCRIPTION
Used to be this: 
![screen shot 2013-09-19 at 1 11 10 pm](https://f.cloud.github.com/assets/4405800/1174867/51f03a06-214f-11e3-9c2c-15a3d0667351.png)

Now handled like this:
![screen shot 2013-09-19 at 1 17 25 pm](https://f.cloud.github.com/assets/4405800/1174875/653dbcf0-214f-11e3-904f-84e81af1825e.png)
