### PR TITLE
Hide results table when there are no results

### DIFF
--- a/src/coffee/cilantro/ui/tables/body.coffee
+++ b/src/coffee/cilantro/ui/tables/body.coffee
@@ -20,9 +20,5 @@ define [
                 collection: model.data
             , @options
 
-        initialize: ->
-            @on 'collection:rendered', ->
-                if @model.series.length == 0
-                    @$el.html('No data to display')
 
     { Body }

--- a/src/coffee/cilantro/ui/tables/table.coffee
+++ b/src/coffee/cilantro/ui/tables/table.coffee
@@ -38,6 +38,12 @@ define [
 
             @$el.append(@header.el, @footer.el)
 
+            @collection.on 'reset', =>
+                if @collection.objectCount == 0
+                    @$el.hide()
+                else
+                    @$el.show()
+
         showCurentPage: (model, num, options) ->
             @children.each (view) ->
                 view.$el.toggle(view.model.id is num)


### PR DESCRIPTION
A while ago, there was a problem where no results left a loading
indicator spinning away in the results table. There was an attempt to
fix this(removed in this commit) but that fix suffered from leaving the
'no data' message showing when paginating. Rather than continue trying
to jam a message into the table, this commit simply hides the whole
table when there are no results. The user can clearly see that there are
0 results(shown in paginator and context panel) so there is no need to
add a third indicator in the table and show table headers without any
actual data.

Fixes #249 
