### PR TITLE
Increase the timeouts for monitored and unmonitored exports

### DIFF
--- a/src/coffee/cilantro/ui/exporter.coffee
+++ b/src/coffee/cilantro/ui/exporter.coffee
@@ -62,10 +62,11 @@ define [
         render: ->
             success = "<span class='label label-success hide'>Done</span>"
             error = "<span class='label label-important hide'>Error</span>"
+            timeout = "<span class='label label-warning label-timeout hide'>Request Timed Out</span>"
             loading = "<div class='progress progress-striped active hide'><div class='bar' style='width: 100%;'></div></div>"
             pending = "<div class=pending-container><span class=pending-spinner></span> Pending...</div>"
 
-            @$el.html("<div class=span2>#{ getTitle(@model) }:</div><div class=span10>#{ success }#{ error }#{ loading }#{ pending }</div>")
+            @$el.html("<div class=span2>#{ getTitle(@model) }:</div><div class=span10>#{ success }#{ error }#{ timeout }#{ loading }#{ pending }</div>")
 
 
     class ExportTypeCollection extends Marionette.CollectionView

--- a/src/coffee/cilantro/ui/workflows/results.coffee
+++ b/src/coffee/cilantro/ui/workflows/results.coffee
@@ -43,10 +43,10 @@ define [
 
         template: templates.results
 
-        requestDelay: 2500      # In milliseconds
-        requestTimeout: 10000   # Max time(ms) for unmonitored exports
-        monitorDelay: 500       # In milliseconds
-        monitorTimeout: 60000   # Max time(ms) to monitor exports
+        requestDelay: 2500       # In milliseconds
+        requestTimeout: 60000    # Max time(ms) for unmonitored exports, 1 minute
+        monitorDelay: 500        # In milliseconds
+        monitorTimeout: 600000   # Max time(ms) to monitor exports, 10 minutes
         numPendingDownloads: 0
         pageRangePattern: /^[0-9]+(\.\.\.[0-9]+)?$/
 
@@ -207,6 +207,8 @@ define [
                     statusContainer.find('.label-important').show()
                 when "success"
                     statusContainer.find('.label-success').show()
+                when "timeout"
+                    statusContainer.find('.label-timeout').show()
 
         onExportFinished: (exportTypeTitle) =>
             @numPendingDownloads = @numPendingDownloads - 1
@@ -214,6 +216,8 @@ define [
 
             if @hasExportErrorOccurred(exportTypeTitle)
                 @changeExportStatus(exportTypeTitle, "error")
+            else if @monitors[exportTypeTitle]["execution_time"] > @monitorTimeout
+                @changeExportStatus(exportTypeTitle, "timeout")
             else
                 @changeExportStatus(exportTypeTitle, "success")
 


### PR DESCRIPTION
For unmonitored exports, all we do is see if an error occurs within the timeout window, if not, we wait until the end of the window and then inform(lie to)? the user that the export succeeded. In modern versions of Serrano that support monitored timeouts, if the request times out then we show a new timeout status to the user. NOTE: This does not abort the request because the damage will already be done on the server(as far as the database is concerned).

Resolves #257.
