### PR TITLE
Fix table header cells to not wrap, but render an ellipsis

### DIFF
--- a/src/coffee/cilantro/ui/tables/header.coffee
+++ b/src/coffee/cilantro/ui/tables/header.coffee
@@ -70,6 +70,7 @@ define [
             # TODO: Could we use a template here instead and then just modify
             # the class on the icon in the template?
             @$el.html("<span>#{ @model.get('name') } <i class=#{ iconClass }></i></span>")
+            @$el.attr('title', @model.get('name'))
 
             return @
 

--- a/src/scss/base/_table.scss
+++ b/src/scss/base/_table.scss
@@ -1,5 +1,6 @@
 table thead th {
     border-left: 1px solid #ddd;
+    max-width: 200px;
 
     &:first-child {
         border-left: 0;
@@ -8,11 +9,15 @@ table thead th {
     span {
         position: relative;
         display: block;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        padding-right: 20px;
 
         // If an icon is present, it is typically denoting the sort order
         i {
             position: absolute;
-            right: 5px;
+            right: 0;
             top: 50%;
 
             // Only about 6/13px are visible, margin is used to offset


### PR DESCRIPTION
A tooltip on the header cell is now available on hover for the full text.
