### PR TITLE
Define the getField method for FieldValueSearch field controls

### DIFF
--- a/src/coffee/cilantro/ui/field/controls/search.coffee
+++ b/src/coffee/cilantro/ui/field/controls/search.coffee
@@ -170,6 +170,8 @@ define [
             # Set the values from the context
             @set(@context)
 
+        getField: -> @model?.id
+
         # This is currently always an 'in', however 'not in' may be
         # desirable as well.
         getOperator: -> 'in'


### PR DESCRIPTION
Previously, the field was always undefined causing the context to
always be invalid. This was preventing the "Apply Filter" button from
ever becoming active.

Fixes #280.
