### PR TITLE
Ensure the distribution endpoint is available for BarChart control

### DIFF
--- a/src/coffee/cilantro/ui/field/form.coffee
+++ b/src/coffee/cilantro/ui/field/form.coffee
@@ -19,7 +19,10 @@ define [
         type = model.get('simple_type')
 
         if model.get('enumerable') or type is 'boolean'
-            infograph.BarChart
+            if model.links.distribution?
+                infograph.BarChart
+            else
+                controls.FieldValueSearch
         else if model.get('searchable')
             controls.FieldValueSearch
         else if type is 'number'


### PR DESCRIPTION
If not, the control will fall back to FieldValueSearch which does not depend
on the distribution. Note this is an upstream issue in Serrano. Once fixed, this
behavior will be reverted.

Fix #285 
