### PR TITLE
Save and render the result count when it is first created

### DIFF
--- a/src/coffee/cilantro/ui/workflows/results.coffee
+++ b/src/coffee/cilantro/ui/workflows/results.coffee
@@ -33,17 +33,11 @@ define [
         modelEvents:
             'change:objectcount': 'renderCount'
 
-        initialize: ->
-            super
-
-            @count = @model.objectCount if @model.objectCount? or ''
-
-        onRender: ->
-            @renderCount(@model, @count)
+        onRender: =>
+            @renderCount(@model, @model.objectCount if @model.objectCount? or '')
 
         renderCount: (model, count, options) ->
-            @count = count
-            numbers.renderCount(@ui.count, @count)
+            numbers.renderCount(@ui.count, count)
             @ui.label.text('records')
 
 


### PR DESCRIPTION
This fixes the issue where the user would navigate to the query workspace first and then to the results workspace leaving the count empty. The reason for this was that the ResultCount view does not exist when the query workspace is hit so the trigger on change:objectcount event was not received by ResultCount since it didn't exist yet. This handles that case by showing the count when it is created and storing the count when the trigger occurs so any possible navigation path should always show the count now.

Fixes #306.
