### PR TITLE
Update public queries on sync AND destroy events on query collection

### DIFF
--- a/src/coffee/cilantro/ui/workflows/workspace.coffee
+++ b/src/coffee/cilantro/ui/workflows/workspace.coffee
@@ -50,7 +50,7 @@ define [
                 # rather than checking if the changed model is public or had
                 # its publicity changed. If this becomes too slow we can
                 # perform these checks but for now this is snappy enough.
-                @data.queries.on 'sync', (model, resp, options) =>
+                @data.queries.on 'sync destroy', (model, resp, options) =>
                     @publicQueries.currentView.collection.fetch()
                     @publicQueries.currentView.collection.reset()
 


### PR DESCRIPTION
This fixes the problem where public queries could be deleted but the list of public queries was not updated until the page was reloaded. Due to recent changes in the way the delete is handled, we need to subscribe to the destroy event in addition to the sync event to account for deletion of models in the query collection.

Fixes #351.
