### PR TITLE
Make concept info categories links for searching that text

### DIFF
--- a/src/coffee/cilantro/ui/concept/info.coffee
+++ b/src/coffee/cilantro/ui/concept/info.coffee
@@ -20,6 +20,14 @@ define [
             category: '.category'
             description: '.description'
 
+        events:
+            'click .category-link': 'onCategoryLinkClick'
+
+        onCategoryLinkClick: (event) ->
+            $('.concept-search > input[type=text]')
+                .val($(event.target).text())
+                .trigger('keyup')
+
         # If the concept does not have it's own description, use the first
         # associated field. However, this currently does not handle the case
         # when the fields have not been loaded yet.

--- a/src/templates/concept/info.html
+++ b/src/templates/concept/info.html
@@ -1,10 +1,10 @@
 <% if (data.category) { %>
     <p class=category>
         <% if (data.category.parent) { %>
-            <%= data.category.parent.name %>
+            <a href='#' class=category-link><%= data.category.parent.name %></a>
             <i class=icon-angle-right></i>
         <% } %>
-        <%= data.category.name %>
+        <a href='#' class=category-link><%= data.category.name %></a>
     </p>
 <% } %>
 


### PR DESCRIPTION
Clicking on the category in the concept info section will populated the search box with that text and trigger the search.

Fixes #146.
