### PR TITLE
Re-render when the facets are reset in concept column control

### DIFF
--- a/src/coffee/cilantro/ui/concept/columns.coffee
+++ b/src/coffee/cilantro/ui/concept/columns.coffee
@@ -183,17 +183,18 @@ define [
             @listenToOnce(@data.view, 'change:json', @resetFacets)
             @listenToOnce(@data.concepts, 'reset', @resetFacets)
 
-            @$el.modal(show: false)
-
-        resetFacets: ->
-            @data.facets.reset(@data.view.facets.toJSON())
-
-        onRender: ->
             # Sync and map between available columns and selected
             # columns (represented as facets)
             @listenTo(@data.concepts, 'columns:add', @addColumn, @)
             @listenTo(@data.facets, 'columns:remove', @removeColumn, @)
 
+            @$el.modal(show: false)
+
+        resetFacets: =>
+            @data.facets.reset(@data.view.facets.toJSON())
+            @render()
+
+        onRender: ->
             @available.show new @regionViews.available
                 collection: @data.concepts
                 collapsable: false


### PR DESCRIPTION
This also moves the event listener registration for add and remove into initialize so they aren't reregistered each time the facets are reset.
