### PR TITLE
Change node identity keys to include operator for multi-condition controls

### DIFF
--- a/spec/models/context/node.js
+++ b/spec/models/context/node.js
@@ -151,8 +151,19 @@ define(['cilantro'], function (c) {
             var cidsAfter = model.children.map(function(model) {
                 return model.cid;
             });
-            expect(model.toJSON()).toEqual(attrs);
-            expect(cidsBefore).toEqual(cidsAfter);
+
+            var sorter = function(a, b) {
+                if (a.concept > b.concept) return 1;
+                else if (a.concept < b.concept) return -1;
+                return 0;
+            };
+
+            // Sort children prior to comparison
+            var merged = model.toJSON();
+            merged.children.sort(sorter);
+
+            expect(merged).toEqual(attrs);
+            expect(cidsBefore).not.toEqual(cidsAfter);
         });
 
         it('should find child node (by field)', function() {

--- a/src/coffee/cilantro/models/context/manager.coffee
+++ b/src/coffee/cilantro/models/context/manager.coffee
@@ -28,7 +28,7 @@ define [
     ###
     class ContextTreeManager extends Evented
         options:
-            identKeys: ['concept', 'field']
+            identKeys: ['concept', 'field', 'operator']
 
         constructor: (@model, options) ->
             @options = _.extend({}, @options, options)

--- a/src/coffee/cilantro/models/context/nodes/base.coffee
+++ b/src/coffee/cilantro/models/context/nodes/base.coffee
@@ -16,7 +16,7 @@ define [
     class ContextNodeModel extends base.SynclessModel
         constructor: (attrs, options={}) ->
             options = _.extend
-                identKeys: ['concept', 'field']
+                identKeys: ['concept', 'field', 'operator']
             , options
 
             @manager = options.manager


### PR DESCRIPTION
In addition this fixes a bug where array equality would always be false.
