### PR TITLE
Increase size of filter button container to prevent stacking

### DIFF
--- a/src/templates/concept/form.html
+++ b/src/templates/concept/form.html
@@ -1,10 +1,10 @@
 <div class=info-region></div>
 <div class=fields-region></div>
 <div class="footer row-fluid">
-    <div class=span7>
+    <div class=span6>
         <div class="state alert"></div>
     </div>
-    <div class="span5 actions">
+    <div class="span6 actions">
         <button data-toggle=remove class="btn btn-danger">Remove Filter</button>
         <button data-toggle=update class="btn btn-primary">Update Filter</button>
         <button data-toggle=apply class="btn btn-success">Apply Filter</button>


### PR DESCRIPTION
Fix #357.

This works on widths down to about 450px. At this size, the whole layout
of the page starts to fall apart starting with the header. I think that
this is the smallest we need to worry about and it looks pretty good
given the span sizes in this commit.
