### PR TITLE
Remove fixed HTML Serrano warning and instead notify on session open

### DIFF
--- a/src/coffee/cilantro/session.coffee
+++ b/src/coffee/cilantro/session.coffee
@@ -217,6 +217,13 @@ define [
             @router.start()
             @startPing()
 
+            if not c.isSupported(c.getSerranoVersion())
+                c.notify
+                    header: 'Serrano Version Unsupported'
+                    message: 'You are connecting to an unsupported version of Serrano. Some functionality may be broken or missing due to compatibility issues.'
+                    level: 'warning'
+                    timeout: false
+
         # Ends/disables the session.
         end: ->
             @started = false

--- a/src/scss/workflows/_query.scss
+++ b/src/scss/workflows/_query.scss
@@ -1,5 +1,2 @@
 .query-workflow {
-    .serrano-version-warning {
-        text-align: center;
-    }
 }

--- a/src/scss/workflows/_results.scss
+++ b/src/scss/workflows/_results.scss
@@ -54,10 +54,6 @@
         z-index: 1;
     }
 
-    .serrano-version-warning {
-        text-align: center;
-    }
-
     .count-region {
         font-weight: bold;
         font-size: 1.4em;

--- a/src/templates/workflows/query.html
+++ b/src/templates/workflows/query.html
@@ -1,11 +1,4 @@
 <div class=row-fluid>
-    <div class="span12 hide serrano-version-warning alert">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <strong>Warning:</strong> You are connecting to an outdated version of Serrano. Some functionality may be broken or missing due to compatibility issues.
-    </div>
-</div>
-
-<div class=row-fluid>
     <div class="concept-panel-region span3"></div>
     <div class="concept-workspace-region span6"></div>
     <div class="context-panel-region span3"></div>

--- a/src/templates/workflows/results.html
+++ b/src/templates/workflows/results.html
@@ -1,11 +1,4 @@
 <div class=row-fluid>
-    <div class="span12 hide serrano-version-warning alert">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        <strong>Warning:</strong> You are connecting to an outdated version of Serrano. Some functionality may be broken or missing due to compatibility issues.
-    </div>
-</div>
-
-<div class=row-fluid>
     <div class="results-container span9">
         <div class=row-fluid>
             <div class=span12>


### PR DESCRIPTION
Fix #209.

This improves on the old behavior because the notification now exists outside of any individual workflow or its HTML meaning there is no duplication of HTML, CSS, or JS to detect and display the warning.
