### PR TITLE
Abstract out logic to determining field type

### DIFF
--- a/src/coffee/cilantro/ui/field/types.coffee
+++ b/src/coffee/cilantro/ui/field/types.coffee
@@ -1,0 +1,11 @@
+define ->
+
+    getFieldType = (model) ->
+        type = model.get('simple_type')
+
+        if model.get('enumerable') or type is 'boolean'
+            return 'choice'
+        else if type in ['number', 'datetime', 'date', 'time']
+            return type
+
+    { getFieldType }


### PR DESCRIPTION
Introduces a getFieldType function for determining a field's logical type
corresponding to the desired interface and behavior for query purposes.

Fix #391
