### PR TITLE
Remove '...' from show/hide filters button

### DIFF
--- a/src/coffee/cilantro/ui/workflows/results.coffee
+++ b/src/coffee/cilantro/ui/workflows/results.coffee
@@ -183,7 +183,7 @@ define [
 
             @ui.toggleFiltersIcon.removeClass('icon-collapse-alt')
             @ui.toggleFiltersIcon.addClass('icon-expand-alt')
-            @ui.toggleFiltersText.html('Hide Filters...')
+            @ui.toggleFiltersText.html('Hide Filters')
             @updateContextPanelOffsets()
             @$('.context').stacked('restack', @$el.height())
 
@@ -203,7 +203,7 @@ define [
 
             @ui.toggleFiltersIcon.addClass('icon-collapse-alt')
             @ui.toggleFiltersIcon.removeClass('icon-expand-alt')
-            @ui.toggleFiltersText.html('Show Filters...')
+            @ui.toggleFiltersText.html('Show Filters')
 
         onPageScroll: =>
             # If the view isn't rendered yet, then don't bother

--- a/src/templates/workflows/results.html
+++ b/src/templates/workflows/results.html
@@ -16,7 +16,7 @@
                                 <i class=icon-save></i> <span class=large-display-button-text>Save Query...</span>
                             </button>
                             <button data-toggle=context-panel class="btn btn-primary btn-mini expand-collapse" title="Hide Filter Panel">
-                                <i class=icon-expand-alt></i> <span class=large-display-button-text>Hide Filters...</span>
+                                <i class=icon-expand-alt></i> <span class=large-display-button-text>Hide Filters</span>
                             </button>
                         </div>
                         <span class="navbar-text count-region"></span>


### PR DESCRIPTION
This ends up saving about 40px of horizontal space in the toolbar which
should allow more room for the text in the count label on the left.
Doesn't seem like much but it is pretty useful in projects like varify
which might have long sample names after the record count. Personally, I
didn't care for the ellipsises either even though I probably added them
in the first place.
