### PR TITLE
Add support for registering AMD module paths to template store

### DIFF
--- a/src/coffee/cilantro.coffee
+++ b/src/coffee/cilantro.coffee
@@ -20,4 +20,12 @@ define [
         c.router = session.router
         c.data = session.data
 
+    # Takes a handler to call once Cilantro has declared itself "ready".
+    c.ready = (handler) ->
+        id = setInterval ->
+            if c.templates.ready()
+                clearTimeout(id)
+                handler()
+        , 15
+
     return (@cilantro = c)

--- a/src/coffee/cilantro/main.coffee
+++ b/src/coffee/cilantro/main.coffee
@@ -15,55 +15,57 @@ require
         url: c.config.get('url')
         credentials: c.config.get('credentials')
 
-    # Open the default session defined in the pre-defined configuration.
-    # Initialize routes once data is confirmed to be available
-    c.sessions.open(options).then ->
+    c.ready ->
 
-        # Define routes
-        routes = [
-            id: 'query'
-            route: 'query/'
-            view: new c.ui.QueryWorkflow
-                context: @data.contexts.session
-                concepts: @data.concepts.queryable
-        ,
-            id: 'results'
-            route: 'results/'
-            view: new c.ui.ResultsWorkflow
-                view: @data.views.session
-                context: @data.contexts.session
-                concepts: @data.concepts.viewable
-                # The differences in these names are noted
-                results: @data.preview
-                exporters: @data.exporter
-                queries: @data.queries
-        ]
+        # Open the default session defined in the pre-defined configuration.
+        # Initialize routes once data is confirmed to be available
+        c.sessions.open(options).then ->
 
-        # Query URLs supported as of 2.2.0
-        if c.isSupported('2.2.0')
-            routes.push
-                id: 'query-load'
-                route: 'results/:query_id/'
-                view: new c.ui.QueryLoader
+            # Define routes
+            routes = [
+                id: 'query'
+                route: 'query/'
+                view: new c.ui.QueryWorkflow
+                    context: @data.contexts.session
+                    concepts: @data.concepts.queryable
+            ,
+                id: 'results'
+                route: 'results/'
+                view: new c.ui.ResultsWorkflow
+                    view: @data.views.session
+                    context: @data.contexts.session
+                    concepts: @data.concepts.viewable
+                    # The differences in these names are noted
+                    results: @data.preview
+                    exporters: @data.exporter
+                    queries: @data.queries
+            ]
+
+            # Query URLs supported as of 2.2.0
+            if c.isSupported('2.2.0')
+                routes.push
+                    id: 'query-load'
+                    route: 'results/:query_id/'
+                    view: new c.ui.QueryLoader
+                        queries: @data.queries
+                        context: @data.contexts.session
+                        view: @data.views.session
+
+            # Workspace supported as of 2.1.0
+            if c.isSupported('2.1.0')
+                data =
                     queries: @data.queries
                     context: @data.contexts.session
                     view: @data.views.session
 
-        # Workspace supported as of 2.1.0
-        if c.isSupported('2.1.0')
-            data =
-                queries: @data.queries
-                context: @data.contexts.session
-                view: @data.views.session
+                # Public queries supported as of 2.2.0
+                if c.isSupported('2.2.0')
+                    data.public_queries = @data.public_queries
 
-            # Public queries supported as of 2.2.0
-            if c.isSupported('2.2.0')
-                data.public_queries = @data.public_queries
+                routes.push
+                    id: 'workspace'
+                    route: 'workspace/'
+                    view: new c.ui.WorkspaceWorkflow(data)
 
-            routes.push
-                id: 'workspace'
-                route: 'workspace/'
-                view: new c.ui.WorkspaceWorkflow(data)
-
-        # Register routes and start the session
-        @start(routes)
+            # Register routes and start the session
+            @start(routes)

--- a/src/js/tpl.js
+++ b/src/js/tpl.js
@@ -1,4 +1,7 @@
 /**
+ * 2014-2-12: Modified for Cilantro to augment the module name as a property
+ * on the returned compiled function.
+ *
  * Adapted from the official plugin text.js
  *
  * Uses UnderscoreJS micro-templates : http://documentcloud.github.com/underscore/#template


### PR DESCRIPTION
To handle the asynchronous nature of loading remote templates, this
introduces a top-level `c.ready()` function that takes a function to
execute once Cilantro is deemed ready. This encapsulates checking for
all the asynchronous operations Cilantro performs prior to being ready
to open a session.

Fix #407
