### PR TITLE
Promote Cilantro controls API to public namespace, `c.controls`

### DIFF
--- a/spec/ui/controls.js
+++ b/spec/ui/controls.js
@@ -1,0 +1,16 @@
+define(['cilantro'], function(c) {
+    describe('Controls', function() {
+        it('should be populated', function() {
+            expect(c.controls).toBeDefined();
+            expect(c.controls.get('number')).toBeDefined();
+        });
+
+        it('should allow override', function() {
+            var NumberControl = c.ui.Control.extend({
+
+            });
+            c.controls.set('number', NumberControl);
+            expect(c.controls.get('number')).toBe(NumberControl);
+        });
+    });
+});

--- a/src/coffee/cilantro.coffee
+++ b/src/coffee/cilantro.coffee
@@ -23,7 +23,7 @@ define [
     # Takes a handler to call once Cilantro has declared itself "ready".
     c.ready = (handler) ->
         id = setInterval ->
-            if c.templates.ready()
+            if c.templates.ready() and c.controls.ready()
                 clearTimeout(id)
                 handler()
         , 15

--- a/src/coffee/cilantro/ui/core.coffee
+++ b/src/coffee/cilantro/ui/core.coffee
@@ -1,8 +1,9 @@
 define [
     'marionette'
     '../core'
-    './templates'
     './notify'
+    './templates'
+    './controls'
     'bootstrap'
     'plugins/bootstrap-datepicker'
     'plugins/jquery-ui'
@@ -10,10 +11,13 @@ define [
     'plugins/jquery-panels'
     'plugins/jquery-scroller'
     'plugins/jquery-stacked'
-], (Marionette, c, templates, notify) ->
+], (Marionette, c, notify, templates, controls) ->
 
-    # Add reference to template cache access methods
-    c.templates = templates
+    # Initialize notification stream and append it to the body
+    stream = new notify.Notifications
+        id: 'cilantro-notifications'
+
+    $('body').append(stream.render().el)
 
     defaultLoadTemplate = Marionette.TemplateCache::loadTemplate
     defaultCompileTemplate = Marionette.TemplateCache::compileTemplate
@@ -30,15 +34,13 @@ define [
             template = defaultCompileTemplate(template)
         return template
 
-    c.templates.set(c.config.get('templates', {}))
+    # Set configuration options for corresponding APIs
+    templates.set(c.config.get('templates', {}))
+    controls.get(c.config.get('controls', {}))
 
-    # Initialize notification stream and append it to the body
-    stream = new notify.Notifications
-        id: 'cilantro-notifications'
-
-    $('body').append(stream.render().el)
-
-    # Attach primary method for creating notifications
+    # Add references public API
     c.notify = stream.notify
+    c.templates = templates
+    c.controls = controls
 
     return c

--- a/src/coffee/cilantro/ui/templates.coffee
+++ b/src/coffee/cilantro/ui/templates.coffee
@@ -68,8 +68,8 @@ define [
 ], (templates...) ->
 
     # Built-in templates and application-defined templates
-    templateCache = {}
-    templateCacheCustom = {}
+    defaultTemplates = {}
+    customTemplates = {}
 
     # Derives a template id from the template's path. This is an internal
     # function that assumes the base directory is under templates/
@@ -82,7 +82,7 @@ define [
     for templateFunc in templates
         templateId = templatePathToId(templateFunc._moduleName)
         templateFunc.templateId = templateId
-        templateCache[templateId] = templateFunc
+        defaultTemplates[templateId] = templateFunc
 
     # Templates can be registered as AMD modules which will be immediately
     # fetched to obtain the resulting compiled template function. This is
@@ -90,11 +90,11 @@ define [
     pendingRemotes = 0
 
     # Loads the remote template and adds it to the custom cache.
-    loadRemoteTemplate = (id, module) ->
+    loadRemote = (id, module) ->
         pendingRemotes++
 
         require [module], (func) ->
-            templateCacheCustom[id] = func
+            customTemplates[id] = func
             pendingRemotes--
         , (err) ->
             pendingRemotes--
@@ -103,16 +103,16 @@ define [
     _set = (id, func) ->
         switch (typeof func)
             when 'function'
-                templateCacheCustom[id] = func
+                customTemplates[id] = func
             when 'string'
-                loadRemoteTemplate(id, func)
+                loadRemote(id, func)
             else
                 throw new Error('template must be a function or AMD module')
 
     # Get the template function by id. Checks the custom cache and falls back
     # to the built-in cache.
     get = (id) ->
-        templateCacheCustom[id] or templateCache[id]
+        customTemplates[id] or defaultTemplates[id]
 
     # Sets a template in cache.
     set = (id, func) ->


### PR DESCRIPTION
This fixes a bug that incorrectly mixed in the controls set/get
methods into the `ui` namespace. This also provides support for
loading modules remotely like the templates API.

The behavior described in #419 is not desirable since the controls
configuration options must be available when Cilantro loads as supposed
to when the session starts.

Close #419
