### PR TITLE
Add support for defining control options in configuration

### DIFF
--- a/src/coffee/cilantro/ui/field/controls.coffee
+++ b/src/coffee/cilantro/ui/field/controls.coffee
@@ -44,12 +44,13 @@ define [
 
         # Renders an item.
         renderItem: (model, index) ->
-            options =
+            options = _.extend {},
                 model: model.get('model')
                 context: model.get('context')
                 index: index
+            , model.get('options')
 
-            controlId = model.get('name')
+            controlId = model.get('control')
 
             # Get the registered control
             controlView = controls.get(controlId)

--- a/src/coffee/cilantro/ui/field/form.coffee
+++ b/src/coffee/cilantro/ui/field/form.coffee
@@ -147,11 +147,17 @@ define [
             if @options.controls
                 controls = []
 
-                for name in @options.controls
-                    controls.push
-                        name: name
+                for options in @options.controls
+                    attrs =
                         model: @model
                         context: @context
+
+                    if _.isObject(options)
+                        _.extend(attrs, options)
+                    else
+                        attrs.control = options
+
+                    controls.push(attrs)
 
                 @controls.show new @regionViews.controls
                     collection: new Backbone.Collection(controls)


### PR DESCRIPTION
The controls array now supports objects with a `control` name and
`options` to be used during control initialization.

Fix #426
