### PR TITLE
Update FieldModel.values to support parameters

### DIFF
--- a/src/coffee/cilantro/models/field.coffee
+++ b/src/coffee/cilantro/models/field.coffee
@@ -52,7 +52,7 @@ define [
             return
 
         values: (params, handler, cache=true) ->
-            # Shift argument is params is not supplied
+            # Shift arguments if params is not supplied
             if typeof params is 'function'
                 handler = params
                 cache = handler


### PR DESCRIPTION
Previously only a query parameter was supported. This has been
changed to support an arbitrary set of parameters. Further, although
passing a callback is still supported, the preferred method is registering
handles with the returned promise.

For example:

``` javascript
f.values({limit: 0}).done(function(values) {
    // do something...
});
```

Fix #425
