### PR TITLE
Update select controls to load all field values

### DIFF
--- a/src/coffee/cilantro/core.coffee
+++ b/src/coffee/cilantro/core.coffee
@@ -28,7 +28,7 @@ define [
         # will be warned if no version number is found or if it is less than this
         # minimum to prepare them in the case of missing or broken functionality.
         minSerranoVersion: '2.0.16'
-        maxSerranoVersion: '2.3.0'
+        maxSerranoVersion: '2.3.1'
 
         # Returns the current session's Serrano version. If there is no
         # active session or version defined, the absolute minimum is returned.


### PR DESCRIPTION
This takes of advantage of the limit=0 parameter in Serrano, but
requires 2.3.1 for it to work correctly.

Fix #423
