### PR TITLE
Add option to toggle condensing multi-field concepts

### DIFF
--- a/src/coffee/cilantro/ui/concept/form.coffee
+++ b/src/coffee/cilantro/ui/concept/form.coffee
@@ -16,6 +16,9 @@ define [
 
         fieldCollectionView: field.FieldFormCollection
 
+        options:
+            condense: false
+
         events:
             'click .footer [data-toggle=apply]': 'applyFilter'
             'click .footer [data-toggle=update]': 'applyFilter'

--- a/src/coffee/cilantro/ui/field/form.coffee
+++ b/src/coffee/cilantro/ui/field/form.coffee
@@ -200,8 +200,9 @@ define [
             # precedence
             if @collection.length < 2
                 options.info = false
-            # The non-primary field are rendered in a condensed view
-            else if index > 0
+            # The condense option causes all fields after the first to render
+            # in a condensed view by default.
+            else if index > 0 and @options.condense
                 options.condensed = true
 
             result = resolveFieldFormOptions(model)


### PR DESCRIPTION
The previous behavior was to render the non-initial field in a more
condensed representation. This tends to denote the non-initial fields are
less important the first one, which should not be the case. The fix
introduces a `ConceptForm` level option `condense` that when set to true
will use the legacy behavior of condensing the non-initial fields. By
default this option is false.

To use the legacy behavior, simply set the `concepts.defaults.form.condense`
to true to apply to all concepts.

Fix #360
