### PR TITLE
Add config option for using fixed view on preview endpoint.

### DIFF
--- a/src/coffee/cilantro/config.coffee
+++ b/src/coffee/cilantro/config.coffee
@@ -21,6 +21,16 @@ define [
         # The selector of the element views will be rendered within.
         main: '#cilantro-main'
 
+        # Session-based configuration options
+        #
+        # Options:
+        # - data: Keys correspond to each resource under the `session.data`
+        # object and the value corresponds to GET or POST data to be used
+        # during a fetch.
+        session:
+            defaults:
+                data: {}
+
         # Timeouts for various components in Cilantro
         timeouts:
             control: 10000

--- a/src/coffee/cilantro/models/results.coffee
+++ b/src/coffee/cilantro/models/results.coffee
@@ -52,10 +52,10 @@ define [
             @_refresh()
 
         fetch: (options={}) =>
-            if c.config.get('preview.view')?
+            if (data = c.config.get('session.defaults.data.preview'))?
                 options.type = 'POST'
                 options.contentType = 'application/json'
-                options.data = JSON.stringify({view: c.config.get('preview.view')})
+                options.data = JSON.stringify(data)
 
             if @isDirty and @isWorkspaceOpen
                 # Since we are making the fetch call immediately below, the


### PR DESCRIPTION
Fix #454.

The view can be specified by setting the preview.view config option. An
example is shown below:

``` json
    preview:
        view:
            columns:[2]
```

or

``` coffeescript
    c.config.set('preview.view', {columns: [2]})
```

In the above example, all calls to the preview endpoint will use a view
composed of only the concept with ID 2. This is an example taken from
varify to use only the sample column in calls to the preview endpoint.
