### PR TITLE
Allow config options to be functions

### DIFF
--- a/src/js/cilantro/utils.js
+++ b/src/js/cilantro/utils.js
@@ -40,7 +40,12 @@ define([
             }
         }
         // Final value of obj is returned
-        return obj;
+        if (typeof obj === 'function') {
+            return obj.apply();
+        }
+        else {
+            return obj;
+        }
     };
 
     // Convenience method for setting a value using the dot-notion for


### PR DESCRIPTION
If a config option is a function, the result of that function will be
returned when getting the config option. Otherwise, the object itself is
returned.

Signed-off-by: Don Naegely naegelyd@gmail.com
