### PR TITLE
Update default session options to use Cilantro config

### DIFF
--- a/src/coffee/cilantro/session.coffee
+++ b/src/coffee/cilantro/session.coffee
@@ -43,11 +43,11 @@ define [
     class Session extends models.Model
         idAttribute: 'url'
 
-        options:
-            pingInterval: 5000
+        options: ->
+            c.config.get('session.defaults')
 
         initialize: (attrs, options) ->
-            @options = _.extend({}, this.options, options)
+            @options = _.extend({}, _.result(@, 'options'), options)
 
             @opened = false
             @started = false
@@ -62,10 +62,10 @@ define [
                 return 'url is required'
 
         startPing: =>
-            # Only if the ping endpoint is available
-            if @links.ping and not @_ping
+            # Only if the ping endpoint is available and has a non-falsy ping interval
+            if @links.ping and @options.ping and not @_ping
                 @ping()
-                @_ping = setInterval(@ping, @options.pingInterval)
+                @_ping = setInterval(@ping, @options.ping)
 
         stopPing: =>
             clearTimeout(@_ping)

--- a/src/js/cilantro/config.js
+++ b/src/js/cilantro/config.js
@@ -22,6 +22,7 @@ define([
          * Sessions
          *
          * - url: The URL of the API
+         * - ping: The ping interval for endpoints that support it.
          * - data: Keys correspond to each resource under the `session.data`
          *   object. The value corresponds to GET or POST data to be
          *   used during a fetch.
@@ -30,6 +31,8 @@ define([
         session: {
             defaults: {
                 url: null,
+                credentials: null,
+                ping: 30000, // 30 seconds
                 data: {}
             }
         },


### PR DESCRIPTION
The default ping interval has been increased to 30 seconds
and can be set at `session.defaults.ping`. If the value is null,
pinging will be disabled.

Fix #481

Signed-off-by: Byron Ruth b@devel.io
