### PR TITLE
Remove embedded columns dialog in results workflow

### DIFF
--- a/src/coffee/cilantro/ui/concept.coffee
+++ b/src/coffee/cilantro/ui/concept.coffee
@@ -7,6 +7,7 @@ define [
     './concept/form'
     './concept/workspace'
     './concept/columns'
+    './concept/dialog'
 ], (_, mods...) ->
 
     _.extend {}, mods...

--- a/src/coffee/cilantro/ui/concept/columns.coffee
+++ b/src/coffee/cilantro/ui/concept/columns.coffee
@@ -2,9 +2,10 @@ define [
     'underscore'
     'marionette'
     '../core'
+    '../base'
     './search'
     './index'
-], (_, Marionette, c, search, index) ->
+], (_, Marionette, c, base, search, index) ->
 
     class AvailableItem extends index.ConceptItem
         template: 'concept/columns-available'
@@ -103,12 +104,18 @@ define [
             collection.add(@model, at: index, silent: true)
 
 
+    class NoneSelectedItem extends base.EmptyView
+        message: 'No columns selected.'
+
+
     class SelectedColumns extends Marionette.CollectionView
         tagName: 'ul'
 
         className: 'selected-columns'
 
         itemView: SelectedItem
+
+        emptyView: NoneSelectedItem
 
         events:
             'sortupdate': 'triggerItemSort'
@@ -149,7 +156,7 @@ define [
         template: 'concept/columns'
 
         events:
-            'click .columns-remove-all-button': 'triggerRemoveAll'
+            'click [data-action=clear]': 'triggerRemoveAll'
 
         regions:
             search: '.search-region'
@@ -163,8 +170,10 @@ define [
 
         initialize: ->
             @data = {}
+
             if not (@data.view = @options.view)
                 throw new Error 'view required'
+
             if not (@data.concepts = @options.concepts)
                 throw new Error 'concepts collection required'
 
@@ -192,6 +201,7 @@ define [
                 collapsable: false
 
             @search.show new @regionViews.search
+                placeholder: 'Search available columns by name, description, or data value...'
                 collection: @data.concepts
                 handler: (query, resp) =>
                     @available.currentView.filter(query, resp)

--- a/src/coffee/cilantro/ui/concept/dialog.coffee
+++ b/src/coffee/cilantro/ui/concept/dialog.coffee
@@ -1,0 +1,58 @@
+define [
+    'underscore'
+    'marionette'
+    './columns'
+], (_, Marionette, columns) ->
+
+    class ColumnsDialog extends Marionette.Layout
+        className: 'columns-modal modal hide full'
+
+        template: 'concept/columns-dialog'
+
+        events:
+            'click [data-save]': 'save'
+            'click [data-dismiss]': 'cancel',
+
+        regions:
+            body: '.modal-body'
+
+        initialize: ->
+            @data = {}
+
+            if not (@data.view = @options.view)
+                throw new Error 'view required'
+
+            if not (@data.concepts = @options.concepts)
+                throw new Error 'concepts collection required'
+
+        onRender: ->
+            @$el.modal
+                show: false
+                keyboard: false
+                backdrop: 'static'
+
+
+            columns = new columns.ConceptColumns
+                view: @data.view
+                concepts: @data.concepts
+
+            this.body.show(columns)
+
+        cancel: ->
+            _.delay =>
+                @body.currentView.resetFacets()
+            , 25
+
+        save: ->
+            @data.view.facets.reset(@body.currentView.data.facets.toJSON())
+            @data.view.save()
+            @close()
+
+        open: ->
+            @$el.modal('show')
+
+        close: ->
+            @$el.modal('hide')
+
+
+    { ColumnsDialog }

--- a/src/coffee/cilantro/ui/templates.coffee
+++ b/src/coffee/cilantro/ui/templates.coffee
@@ -23,6 +23,7 @@ define [
     'tpl!templates/concept/columns-available.html'
     'tpl!templates/concept/columns-selected.html'
     'tpl!templates/concept/columns.html'
+    'tpl!templates/concept/columns-dialog.html'
     'tpl!templates/concept/error.html'
     'tpl!templates/concept/form.html'
     'tpl!templates/concept/info.html'

--- a/src/js/cilantro/main.js
+++ b/src/js/cilantro/main.js
@@ -39,12 +39,31 @@ require({
                 })
             };
 
+            c.dialogs = {
+                columns: new c.ui.ColumnsDialog({
+                    view: this.data.views.session,
+                    concepts: this.data.concepts.viewable
+                })
+            };
+
+            var elements = [];
+
             // Render and append panels in the designated main element
             // prior to starting the session and loading the initial workflow
-            c.panels.concept.render();
-            c.panels.context.render();
+            // Render and append element for insertion
+            $.each(c.panels, function(key, view) {
+                view.render();
+                elements.push(view.el);
+            });
 
-            $(c.config.get('main')).append(c.panels.concept.el, c.panels.context.el);
+            $.each(c.dialogs, function(key, view) {
+                view.render();
+                elements.push(view.el);
+            });
+
+            // Set the initial HTML with all the global views
+            var main = $(c.config.get('main'));
+            main.append.apply(main, elements);
 
             c.workflows = {
                 query: new c.ui.QueryWorkflow({
@@ -55,7 +74,6 @@ require({
                 results: new c.ui.ResultsWorkflow({
                     view: this.data.views.session,
                     context: this.data.contexts.session,
-                    concepts: this.data.concepts.viewable,
                     // The differences in these names are noted
                     results: this.data.preview,
                     exporters: this.data.exporter,

--- a/src/js/cilantro/ui/workflows/results.js
+++ b/src/js/cilantro/ui/workflows/results.js
@@ -9,10 +9,9 @@ define([
     '../numbers',
     '../tables',
     '../context',
-    '../concept',
     '../exporter',
     '../query'
-], function($, _, Marionette, c, paginator, numbers, tables, context, concept, exporter, query) {
+], function($, _, Marionette, c, paginator, numbers, tables, context, exporter, query) {
 
     var ResultCount = Marionette.ItemView.extend({
         tagName: 'span',
@@ -51,7 +50,6 @@ define([
      * to alternate formats.
      *
      * This view requires the following options:
-     *      - concepts: a collection of concepts that are deemed viewable
      *      - context: the session/active context model
      *      - view: the session/active view model
      *      - results: a Results collection that contains the tabular data
@@ -79,7 +77,6 @@ define([
         pageRangePattern: /^[0-9]+(\.\.\.[0-9]+)?$/,
 
         ui: {
-            columns: '.columns-modal',
             saveQuery: '.save-query-modal',
             saveQueryToggle: '[data-toggle=save-query]',
             exportOptions: '.export-options-modal',
@@ -94,22 +91,19 @@ define([
         },
 
         events: {
-            'click .columns-modal [data-save]': 'saveColumns',
-            'click .columns-modal [data-dismiss]': 'cancelColumnChanges',
-            'click [data-toggle=columns]': 'showColumns',
             'click .export-options-modal [data-save]': 'exportData',
             'click [data-toggle=export-options]': 'showExportOptions',
             'click [data-toggle=export-progress]': 'showExportProgress',
             'click #pages-text-ranges': 'selectPagesOption',
             'click [data-toggle=save-query]': 'showSaveQuery',
-            'click [data-toggle=context-panel]': 'toggleContextPanelButtonClicked'
+            'click [data-toggle=context-panel]': 'toggleContextPanelButtonClicked',
+            'click [data-toggle=columns-dialog]': 'showColumnsDialog'
         },
 
         regions: {
             count: '.count-region',
             table: '.table-region',
             paginator: '.paginator-region',
-            columns: '.columns-modal .modal-body',
             exportTypes: '.export-options-modal .export-type-region',
             exportProgress: '.export-progress-modal .export-progress-region',
             saveQueryModal: '.save-query-modal'
@@ -127,9 +121,6 @@ define([
             }
             if (!(this.data.view = this.options.view)) {
                 throw new Error('view model required');
-            }
-            if (!(this.data.concepts = this.options.concepts)) {
-                throw new Error('concepts collection required');
             }
             if (!(this.data.results = this.options.results)) {
                 throw new Error('results collection required');
@@ -472,10 +463,6 @@ define([
                 collection: this.data.results
             }));
 
-            this.columns.show(new concept.ConceptColumns({
-                view: this.data.view,
-                concepts: this.data.concepts
-            }));
 
             this.ui.navbarButtons.tooltip({
                 animation: false,
@@ -500,28 +487,14 @@ define([
             this.ui.exportProgress.modal('show');
         },
 
-        showColumns: function() {
-            this.ui.columns.modal('show');
+        showColumnsDialog: function() {
+            c.dialogs.columns.open();
         },
 
         showSaveQuery: function() {
             // Opens the query modal without passing a model which assumes a
             // new one will be created based on the current session.
             this.saveQueryModal.currentView.open();
-        },
-
-        cancelColumnChanges: function() {
-            var _this = this;
-
-            _.delay(function() {
-                _this.columns.currentView.resetFacets();
-            }, 25);
-        },
-
-        saveColumns: function() {
-            this.data.view.facets.reset(this.columns.currentView.data.facets.toJSON());
-            this.data.view.save();
-            this.ui.columns.modal('hide');
         }
     });
 

--- a/src/scss/views/_concept-columns.scss
+++ b/src/scss/views/_concept-columns.scss
@@ -1,4 +1,58 @@
 .concept-columns {
+    height: 100%;
+    position: relative;
+
+    .available-column {
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 48%;
+
+        > * {
+            position: absolute;
+            left: 0;
+            right: 0;
+        }
+
+        .search-region {
+            top: 0px;
+        }
+
+        .available-region {
+            top: 40px;
+            bottom: 0;
+            overflow-y: auto;
+        }
+    }
+
+    .selected-column {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        width: 48%;
+
+        > * {
+            position: absolute;
+            left: 0;
+            right: 0;
+        }
+
+        .toolbar {
+            top: 0px;
+
+            button {
+                float: right;
+            }
+        }
+
+        .selected-region {
+            top: 40px;
+            bottom: 0;
+            overflow-y: auto;
+        }
+    }
 
     .selected-columns, .available-columns {
         margin-left: 0;
@@ -10,7 +64,7 @@
             button {
                 position: absolute;
                 right: 0;
-                top: 3px;
+                top: 4px;
             }
 
             &.disabled {
@@ -22,24 +76,45 @@
         }
     }
 
+    .available-columns .group {
+        border: 0;
+        padding: 0;
+        background: inherit;
+
+        > .heading {
+            cursor: default;
+        }
+    }
+
     .selected-columns {
         list-style: none;
         margin-left: 0;
         cursor: move;
 
-        li:hover, .ui-sortable-helper, .placeholder {
+        li {
+            padding-right: 5px;
+            padding-left: 5px;
+
+            button {
+                right: 5px;
+            }
+        }
+
+        li:hover {
             background-color: #fcf8e3;
         }
 
         .ui-sortable-helper {
-            box-shadow: 0 2px 3px #ccc;
+            box-shadow: 0 1px 5px #ddd;
+            border-radius: 3px;
         }
 
         .placeholder {
-            height: 26px;
+            border: 2px dashed #aaa;
+            height: 22px;
         }
     }
-    
+
     .columns-remove-all-button {
         margin-top: 5px;
     }

--- a/src/templates/concept/columns-dialog.html
+++ b/src/templates/concept/columns-dialog.html
@@ -1,0 +1,10 @@
+<div class=modal-header>
+    <h3>Change Columns <small>Add, remove, and reorder columns for output</small></h3>
+</div>
+
+<div class=modal-body></div>
+
+<div class=modal-footer>
+    <button data-dismiss=modal class=btn>Cancel</button>
+    <button data-save class="btn btn-primary">Save</button>
+</div>

--- a/src/templates/concept/columns.html
+++ b/src/templates/concept/columns.html
@@ -1,18 +1,12 @@
-<div class=row-fluid>
-    <div class=span6>
-        <p class=muted>Below are the columns of data that are available for
-            viewing. Note that depending on which columns are added to your
-            report, the the number of rows may change.</p>
-        <div class="search-region"></div>
-        <div class="available-region"></div>
+<div class=available-column>
+    <div class="search-region"></div>
+    <div class="available-region"></div>
+</div>
+
+<div class=selected-column>
+    <div class=toolbar>
+        <button type=button data-action=clear class="btn btn-mini btn-danger"><i class="icon-remove icon-white"></i> Clear</button>
+        <strong>Click, drag and drop</strong> to change the order.
     </div>
-    <div class=span6>
-        <p class=muted>
-            The order below (top-bottom) defines the order they
-            will be displayed (left-right). To change the order simply
-            click and drag any of the columns to the desired position.
-        </p>
-        <p class=clearfix><button class="btn btn-mini btn-danger pull-right columns-remove-all-button"><i class="icon-remove icon-white"></i></button></p>
-        <div class="selected-region"></div>
-    </div>
+    <div class="selected-region"></div>
 </div>

--- a/src/templates/workflows/results.html
+++ b/src/templates/workflows/results.html
@@ -2,7 +2,7 @@
     <div class="navbar-inner">
         <div class="navbar-text pull-right">
             <span class="paginator-region"></span>
-            <button data-toggle=columns class="btn btn-primary btn-mini" title="Change Columns">
+            <button data-toggle=columns-dialog class="btn btn-primary btn-mini" title="Change Columns">
                 <i class=icon-columns></i> <span class=large-display-button-text>Change Columns...</span>
             </button>
             <button data-toggle=export-options class="btn btn-primary btn-mini" title="Export Data">
@@ -85,19 +85,6 @@
     <div class=modal-footer>
         <button data-dismiss=modal class=btn>Close</button>
         <button data-save class="btn btn-primary">Export</button>
-    </div>
-</div>
-
-<div class="columns-modal modal hide full" data-keyboard="false" data-backdrop="static">
-    <div class=modal-header>
-        <h3>Change Columns <small>Add, remove, and reorder columns for output</small></h3>
-    </div>
-
-    <div class=modal-body></div>
-
-    <div class=modal-footer>
-        <button data-dismiss=modal class=btn>Cancel</button>
-        <button data-save class="btn btn-primary">Save</button>
     </div>
 </div>
 


### PR DESCRIPTION
The columns dialog is now accessible via `cilantro.dialogs.columns`.
In addition, style enhancements have been made to the dialog. The
available and selected column regions can now independently scroll.

Signed-off-by: Byron Ruth b@devel.io
