### PR TITLE
Fix broken debouncing on search control textbox

### DIFF
--- a/src/js/cilantro/ui/search.js
+++ b/src/js/cilantro/ui/search.js
@@ -24,15 +24,18 @@ define([
         },
 
         events: {
-            'keyup @ui.input': 'triggerSearch'
+            'keyup @ui.input': '_triggerSearch'
         },
 
         constructor: function(options) {
+            // This event needs to be debounced before the call to the super
+            // constructor or the keyup event will not be mapped to any handler
+            // since _triggerSearch won't exist yet.
+            this._triggerSearch = _.debounce(this.triggerSearch, this.options.delay);
+
             Marionette.ItemView.prototype.constructor.call(this, options);
 
             this._query = '';
-
-            this.trggerSearch = _.debounce(this.triggerSearch, this.options.delay);
 
             // If this is triggered externally, ensure the input text reflects the
             // query.


### PR DESCRIPTION
Fix #502.

The issue was that the triggerSearch event wasn't debounced until after the call to the super constructor. This meant that the event was already bound to the non-debounced version of triggerSearch before triggerSearch became debounced. I changed the ordering and added a new _triggerSearch method for clarity.

Signed-off-by: Don Naegely naegelyd@gmail.com
