### PR TITLE
Add validate method to search control

### DIFF
--- a/src/js/cilantro/ui/controls/search.js
+++ b/src/js/cilantro/ui/controls/search.js
@@ -233,8 +233,23 @@ define([
         },
 
         validate: function() {
-            var invalid = [];
+            var pending, invalid = [];
 
+            // If a call is still pending, warn the user that they are too
+            // fast for their own good and to try again in a bit.
+            pending = this.collection.any(function(value) {
+                return value.get('pending') === true;
+            });
+
+            if (pending) {
+                return 'The values are being checked, please wait a few ' +
+                       'seconds then click &quot;Apply Filter&quot; again.';
+            }
+
+            // Get a list of labels for all the elements in the collection that
+            // were found to be invalid during the last call to the values
+            // endpoint on the server. If no such elements exist, then this
+            // control is deemed valid.
             this.collection.each(function(value) {
                 if (!value.get('valid')) {
                     invalid.push(value.get('label'));


### PR DESCRIPTION
Fix #513. 

This validate method will tell the user which labels are invalid and instructs the user to remove them.

Signed-off-by: Don Naegely naegelyd@gmail.com
