### PR TITLE
Added threshold for not rounding numbers

### DIFF
--- a/src/coffee/cilantro/ui/numbers.coffee
+++ b/src/coffee/cilantro/ui/numbers.coffee
@@ -9,5 +9,5 @@ define [
         if not count?
             $el.html(fallback)
         else
-            $el.html(c.utils.prettyNumber(count))
-                .attr('title', c.utils.toDelimitedNumber(count))
+            $el.html(c.utils.prettyNumber(count, c.config.get('threshold')))
+                           .attr('title', c.utils.toDelimitedNumber(count))

--- a/src/js/cilantro/config.js
+++ b/src/js/cilantro/config.js
@@ -42,6 +42,13 @@ define([
 
         // Convenience option: Credentials for the default session
         credentials: null,
+        /*
+         * Threshold for showing counts of results as rounded and/or
+         * prefixed numbers. set this threshold to be a number and if the
+         * displayed counts are less than the threshold, there will be no
+         * rounding and the count will be displayed as is (precise).
+         */
+         threshold: null,
 
 
         /*

--- a/src/js/cilantro/ui/context/actions.js
+++ b/src/js/cilantro/ui/context/actions.js
@@ -29,7 +29,7 @@ define([
 
         serializeData: function() {
             var attrs = _.clone(this.model.attributes);
-            attrs.prettyCount = c.utils.prettyNumber(attrs.count);
+            attrs.prettyCount = c.utils.prettyNumber(attrs.count, c.config.get('threshold'));
             return attrs;
         },
 

--- a/src/js/cilantro/utils/numbers.js
+++ b/src/js/cilantro/utils/numbers.js
@@ -31,10 +31,17 @@ define(function() {
         return !(value === undefined || value === null || value === '');
     };
 
-    var toSuffixedNumber = function(value) {
+    var toSuffixedNumber = function(value, threshold) {
         if (!parsable(value)) return;
 
-        if (value < 1000) return toDelimitedNumber(value);
+        // If our number is less than the set threshold,
+        // do not proceed with rounding or making it pretty
+        if (value < 1000 && threshold === null) {
+            return toDelimitedNumber(value);
+        }
+        else if (value <= threshold){
+            return value;
+        }
 
         var exp, suffix, largeNum, newValue;
         for (var i = 0; i < suffixes.length; i++) {
@@ -75,7 +82,7 @@ define(function() {
         return text;
     };
 
-    var prettyNumber = function(value) {
+    var prettyNumber = function(value, threshold) {
         if (!parsable(value)) return;
 
         if (value !== 0) {
@@ -89,7 +96,7 @@ define(function() {
             }
         }
 
-        return toSuffixedNumber(value);
+        return toSuffixedNumber(value, threshold);
     };
 
     return {


### PR DESCRIPTION
Fix #314
Due to the nature of the utils file, it is unreasonable to import core.js due to circular dependency issues. Thus, a new argument `threshold` has been added to `prettyNumber(value, threshold)` which defaults to null. This argument can be passed in from the `ui` .js files in which importing core.js is fine.

Signed-off-by: Sheik Hassan solergiga@yahoo.com
