### PR TITLE
Columns cannot be saved with empty columns

### DIFF
--- a/src/js/cilantro/ui/concept/columns/dialog.js
+++ b/src/js/cilantro/ui/concept/columns/dialog.js
@@ -17,8 +17,12 @@ define([
             'click [data-dismiss]': 'cancel'
         },
 
+        ui: {
+             error: '[data-target=error]'
+        },
+
         regions: {
-            body: '.modal-body'
+            body: '.concept-columns-region'
         },
 
         regionViews: {
@@ -62,12 +66,21 @@ define([
         },
 
         save: function() {
-            this.data.view.facets.reset(this.columns.selectedToFacets());
+            this.ui.error.hide();
+            var facets = this.columns.selectedToFacets();
+
+            if (facets.length === 0) {
+                this.ui.error.html('<p>You must select one or more columns.</p>').show();
+                return;
+            }
+
+            this.data.view.facets.reset(facets);
             this.data.view.save();
             this.close();
         },
 
         open: function() {
+            this.ui.error.hide();
             this.$el.modal('show');
         },
 

--- a/src/scss/views/_concept-columns.scss
+++ b/src/scss/views/_concept-columns.scss
@@ -1,3 +1,7 @@
+.concept-columns-region {
+    height: 100%;
+}
+
 .concept-columns {
     height: 100%;
     position: relative;

--- a/src/templates/concept/columns/dialog.html
+++ b/src/templates/concept/columns/dialog.html
@@ -2,9 +2,12 @@
     <h3>Change Columns <small>Add, remove, and reorder columns for output</small></h3>
 </div>
 
-<div class=modal-body></div>
+<div class=modal-body>
+    <div data-target=error class='alert alert-error alert-block hide'></div>
+    <div class='row-fluid concept-columns-region'></div>
+</div>
 
 <div class=modal-footer>
     <button data-dismiss=modal class=btn>Cancel</button>
-    <button data-save class="btn btn-primary">Save</button>
+    <button data-save class='btn btn-primary'>Save</button>
 </div>


### PR DESCRIPTION
Fix #542 An error message is displayed when a user attempts to save the columns dialog and has not selected any columns.

Signed-off-by: Sheik Hassan solergiga@yahoo.com
