### PR TITLE
Remove isValidValue in favor of reusing validateFilter

### DIFF
--- a/src/coffee/cilantro/ui/controls/select.coffee
+++ b/src/coffee/cilantro/ui/controls/select.coffee
@@ -92,6 +92,10 @@ define [
         setValue: (value) ->
             @ui.items.val(value)
 
+        validate: (attrs) ->
+            if _.isNull(attrs.value) or _.isUndefined(attrs.value)
+                return 'An option must be selected'
+
 
     class MultiSelectionList extends SingleSelectionList
         onCollectionSync: ->
@@ -116,6 +120,10 @@ define [
         setValue: (values=[]) ->
             @collection.each (model) ->
                 model.set('selected', model.get('value') in values)
+
+        validate: (attrs) ->
+            if not attrs.value or not attrs.value.length
+                return 'At least one option must be selected'
 
 
     { SingleSelectionList, MultiSelectionList }

--- a/src/js/cilantro/ui/controls/range.js
+++ b/src/js/cilantro/ui/controls/range.js
@@ -226,7 +226,7 @@ define([
 
         validate: function(attrs) {
             // One of the bounds must be defined
-            if (_.isUndefined(attrs.value)) {
+            if (_.isUndefined(attrs.value) || _.isNull(attrs.value)) {
                 return 'A lower or upper value must be defined';
             }
 

--- a/src/js/cilantro/ui/controls/search.js
+++ b/src/js/cilantro/ui/controls/search.js
@@ -232,7 +232,7 @@ define([
             this.collection.set(value, {merge: false});
         },
 
-        validate: function() {
+        validate: function(attrs) {
             var pending, invalid = [];
 
             // If a call is still pending, warn the user that they are too
@@ -259,6 +259,10 @@ define([
             if (invalid.length) {
                 return 'Remove the following invalid labels then click ' +
                        '&quot;Apply Filter&quot; again: ' + invalid.join(', ');
+            }
+
+            if (attrs && (!attrs.value || !attrs.value.length)) {
+                return 'At least one value must be selected';
             }
         }
 

--- a/src/js/cilantro/ui/field/form.js
+++ b/src/js/cilantro/ui/field/form.js
@@ -187,20 +187,6 @@ define([
             this.chart.show(new this.regionViews.chart(options));
         },
 
-        _isValueValid: function(value) {
-            // Since values can be arrays(range control, search control, etc.)
-            // and single values(range control, single selection control, etc.)
-            // we need to check that the value is either a non-empty array or
-            // a non-null single value to be considered valid and enable the
-            // buttons.
-            if (_.isArray(value)) {
-                return !_.isEmpty(value);
-            }
-            else {
-                return value !== null && value !== undefined;
-            }
-        },
-
         renderFilter: function() {
             this.ui.apply.prop('disabled', true);
             this.ui.update.prop('disabled', true);
@@ -222,7 +208,7 @@ define([
                 });
 
                 if (this.data.context.hasFilterChanged(this.data.filter, keys)) {
-                    if (this._isValueValid(this.data.filter.get('value'))) {
+                    if (this.validateFilter({silent: true})) {
                         this.ui.apply.prop('disabled', false);
                         this.ui.update.prop('disabled', false);
                     }
@@ -231,13 +217,15 @@ define([
             else {
                 this.ui.apply.show();
                 this.ui.update.hide();
-                if (this._isValueValid(this.data.filter.get('value'))) {
+                if (this.validateFilter({silent: true})) {
                     this.ui.apply.prop('disabled', false);
                 }
             }
         },
 
-        validateFilter: function() {
+        validateFilter: function(options) {
+            options = _.extend({}, options);
+
             var message,
                 messages = [],
                 attrs = this.data.filter.toJSON();
@@ -252,7 +240,9 @@ define([
 
             if (messages.length) {
                 this.validationErrors = messages;
-                this.ui.state.html(messages.join('<br>')).show();
+                if (!options.silent) {
+                    this.ui.state.html(messages.join('<br>')).show();
+                }
                 return false;
             }
 


### PR DESCRIPTION
The isValidValue method was too general and did not handle branching
filters.

The validateFilter method has been extended to support validating without
displaying the error message by passing the silent: true option. Assuming
each control implements a validate method, this will work as expected.

Fix #546

Signed-off-by: Byron Ruth b@devel.io
