### PR TITLE
Set value to null when range boxes are empty

### DIFF
--- a/src/js/cilantro/ui/controls/range.js
+++ b/src/js/cilantro/ui/controls/range.js
@@ -157,6 +157,9 @@ define([
             else if (!_.isUndefined(upper)) {
                 value = upper;
             }
+            else {
+                value = null;
+            }
 
             return value;
         },


### PR DESCRIPTION
Fix #533.

This fixes an issue where a value was entered in the textbox then the textbox was removed and the apply 
button remained enabled. The apply button is now disabled in the case described above.

Signed-off-by: Don Naegely naegelyd@gmail.com
