### PR TITLE
Show tooltip only when toolbar buttons are minimized to icons

### DIFF
--- a/src/scss/workflows/_results.scss
+++ b/src/scss/workflows/_results.scss
@@ -25,6 +25,14 @@
             }
         }
 
+        @media (min-width: 1200px) {
+            .navbar-inner {
+                .tooltip {
+                    visibility: hidden;
+               }
+            }
+        }
+
         .navbar-inner {
             padding-left: 5px;
             padding-right: 5px;


### PR DESCRIPTION
Fix #441
The tooltips get injected into the navbar-inner div. So it is much easier this way
Signed-off-by: Sheik Hassan solergiga@yahoo.com
