### PR TITLE
Correct mistranslated reference to super in Results fetch call

### DIFF
--- a/src/js/cilantro/models/results.js
+++ b/src/js/cilantro/models/results.js
@@ -83,7 +83,7 @@ define([
                     options.cache = false;
                 }
 
-                return Results.prototype.fetch.call(this, options);
+                return structs.FrameArray.prototype.fetch.call(this, arguments);
             }
             else {
                 // If the results aren't dirty or the workspace isn't open then


### PR DESCRIPTION
Fix #590, #591.

Signed-off-by: Don Naegely naegelyd@gmail.com
