### PR TITLE
Check for paginator abort method before calling

### DIFF
--- a/src/js/cilantro/models/paginator.js
+++ b/src/js/cilantro/models/paginator.js
@@ -16,7 +16,9 @@ define([
                 // Request already being made, otherwise abort
                 if (url === this.pending.url) return;
 
-                this.pending.abort();
+                if (this.pending.abort) {
+                    this.pending.abort();
+                }
             }
 
             var _this = this;


### PR DESCRIPTION
I was seeing periodic errors(never tracked down the definite steps to recreate since this was such an easy fix) where an error would be thrown saying that abort was undefined and could not be called. This was because pending was set to `true` in some cases and, in those cases, had no `abort()`.

Signed-off-by: Don Naegely naegelyd@gmail.com
