### PR TITLE
Updated turboThreshold in highchart options

### DIFF
--- a/src/coffee/cilantro/ui/charts/options.coffee
+++ b/src/coffee/cilantro/ui/charts/options.coffee
@@ -41,7 +41,7 @@ define ->
                 shadow: false
                 borderWidth: 0
                 borderColor: '#4b8cf7'
-                turboThreshold: 5500
+                turboThreshold: 0
                 animation:
                     duration: 400
                 color: '#777'


### PR DESCRIPTION
Very small change. High charts for large data fail w/o it.
Fix #616 
Signed-off-by: Sheik Hassan solergiga@yahoo.com
