### PR TITLE
Selections are reset after cancel in columns dialog

### DIFF
--- a/src/js/cilantro/ui/concept/columns/dialog.js
+++ b/src/js/cilantro/ui/concept/columns/dialog.js
@@ -63,6 +63,8 @@ define([
             _.delay(function() {
                 _this.columns.resetSelected();
             }, 25);
+
+            this.render();
         },
 
         save: function() {


### PR DESCRIPTION
Fix #626 
Simple change does the trick
Signed-off-by: Sheik Hassan solergiga@yahoo.com
