### PR TITLE
Don't set range control inputs when input has focus

### DIFF
--- a/src/js/cilantro/ui/controls/range.js
+++ b/src/js/cilantro/ui/controls/range.js
@@ -161,6 +161,13 @@ define([
             return value;
         },
 
+        isFocused: function(element) {
+            // We need to compare the element against the activeElement on the
+            // document because the :focus psuedoselector is buggy in some
+            // browsers.
+            return document.activeElement === element;
+        },
+
         setOperator: function(operator) {
             // All other operators (lte, gte, etc.) default to the 'range'
             // selection by default.
@@ -182,7 +189,12 @@ define([
         },
 
         setLowerBoundValue: function(value) {
-            this.ui.lowerBound.val(value);
+            // Since ui.upperBound is techinically just the result of a selector
+            // it is really an array so we use the first element to check for
+            // the focused state.
+            if (!this.isFocused(this.ui.lowerBound[0])) {
+                this.ui.lowerBound.val(value);
+            }
         },
 
         // This method updates the upper bound text box placeholder with the
@@ -196,7 +208,12 @@ define([
         },
 
         setUpperBoundValue: function(value) {
-            this.ui.upperBound.val(value);
+            // Since ui.upperBound is techinically just the result of a selector
+            // it is really an array so we use the first element to check for
+            // the focused state.
+            if (!this.isFocused(this.ui.upperBound[0])) {
+                this.ui.upperBound.val(value);
+            }
         },
 
         // Override set method due to the dependency of the operator


### PR DESCRIPTION
Fix #631 

Signed-off-by: Don Naegely naegelyd@gmail.com
