### PR TITLE
Fix case where chart loading indicator was not always removed

### DIFF
--- a/src/coffee/cilantro/ui/charts/core.coffee
+++ b/src/coffee/cilantro/ui/charts/core.coffee
@@ -76,8 +76,8 @@ define [
                 message: 'No data is available for charting'
             @$el.html(view.render().el)
 
-        onChartLoaded: ->
-            $('.load-view').remove()
+        onChartLoaded: =>
+            @$el.find('.load-view').remove()
 
         renderChart: (options) ->
             view = new @loadView


### PR DESCRIPTION
Fix #630. 

A more localized lookup is now performed so even if the HTML is not
rendered in the DOM, it will still be removed.

Signed-off-by: Don Naegely naegelyd@gmail.com
