### PR TITLE
Changes to setup to handle harvest apps with welcome pages

### DIFF
--- a/src/js/cilantro/setup.js
+++ b/src/js/cilantro/setup.js
@@ -81,7 +81,8 @@ define([
     $(document).ajaxError(function(event, xhr, settings, exception) {
         // A statusText value of 'abort' is an aborted request which is
         // usually intentional by the app or from a page reload.
-        if (xhr.statusText === 'abort') return;
+        if (xhr.statusText === 'abort' ||
+            (xhr.status >= 300 && xhr.status < 400) ) return;
 
         var message = '';
 
@@ -95,6 +96,7 @@ define([
                 '<a href="#" onclick="location.reload()">Refreshing</a> ' +
                 'the page may help.';
         }
+
         c.notify({
             timeout: null,
             dismissable: true,


### PR DESCRIPTION
This PR tried addressing the issue
https://github.com/cbmi/cilantro/pull/659

But the solution was app specific. The problem was determined to be omop harvest returning at status code 302 and the ajaxError code does not handle this case.

Signed-off-by: Sheik Hassan solergiga@yahoo.com
