### PR TITLE
Improve formatting and layout of field form

### DIFF
--- a/src/js/cilantro/ui/field/stats.js
+++ b/src/js/cilantro/ui/field/stats.js
@@ -39,7 +39,7 @@ define ([
                 distinct_count: 'Unique values' // jshint ignore:line
             };
             return '<span class=stat-label>' + (statslabel[data.key] || data.key) +
-                   '</span> <span class=stat-value title="' + data.value + '">' +
+                   ':</span> <span class=stat-value title="' + data.value + '">' +
                    (prettyValue(data.value)) + '</span>';
         }
     });

--- a/src/scss/views/_field-stats.scss
+++ b/src/scss/views/_field-stats.scss
@@ -1,10 +1,11 @@
 .field-stats {
+    border-bottom: 1px solid #ddd;
+    display: inline-block;
     font-size: 0.9em;
     min-height: 21px;
-    margin-bottom: 20px;
 
     ul {
-        margin-left: 0;
+        margin: 0;
         list-style: none;
     }
 
@@ -15,15 +16,11 @@
 
     .stat-label {
         font-weight: 200;
-        background-color: #eee;
-        text-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
-        border-radius: 3px 0 0 3px;
         padding: 2px 5px;
     }
 
     .stat-value {
         font-weight: 500;
         padding: 0 5px;
-        border-bottom: 2px solid #eee;
     }
 }

--- a/src/templates/field/form.html
+++ b/src/templates/field/form.html
@@ -1,7 +1,7 @@
 <div class=info-region></div>
+<div class=controls-region></div>
 <div class=stats-region></div>
 <div class=chart-region></div>
-<div class=controls-region></div>
 
 <div class=actions-region>
     <button data-action=update class="btn btn-primary btn-small">Update Filter</button>


### PR DESCRIPTION
Fix #361.

Move controls nearer to name and description while the stats are closer to the chart.

Signed-off-by: Don Naegely naegelyd@gmail.com
