### PR TITLE
Add Cilantro focus/blur events for toggling session ping

### DIFF
--- a/src/js/cilantro/session.js
+++ b/src/js/cilantro/session.js
@@ -279,7 +279,9 @@ define([
             // When the page loses focus, stop pinging, resume when visibility is regained
             this.listenTo(c, {
                 visible: this.startPing,
-                hidden: this.stopPing
+                hidden: this.stopPing,
+                focus: this.startPing,
+                blur: this.stopPing
             });
 
             if (!c.isSupported(c.getSerranoVersion())) {

--- a/src/js/cilantro/setup.js
+++ b/src/js/cilantro/setup.js
@@ -196,4 +196,14 @@ define([
             window.onfocus = window.onblur = onchange;
     }
 
+    // Handlers for the window blur/focus events to support tracking. The
+    // primary use of these events is to toggle pinging the server when the
+    // window goes out of focus.
+    window.onblur = function() {
+        c.trigger('blur');
+    };
+
+    window.onfocus = function() {
+        c.trigger('focus');
+    };
 });


### PR DESCRIPTION
The visibility API does not consider a window to be hidden when the
window is in the background. The blur/focus handlers are more general
and trigger if the window is not in the foreground.

Signed-off-by: Byron Ruth b@devel.io
