### PR TITLE
Defer rendering query details until concepts are loaded

### DIFF
--- a/src/js/cilantro/ui/query/item.js
+++ b/src/js/cilantro/ui/query/item.js
@@ -173,7 +173,16 @@ define([
         },
 
         onRender: function() {
-            this.renderDetails();
+            // The details requires the concepts to be loaded. This checks
+            // based on existence, otherwise waits until they sync.
+            if (c.data.concepts.length) {
+                this.renderDetails();
+            }
+            else {
+                this.listenTo(c.data.concepts, 'sync', function() {
+                    this.renderDetails();
+                });
+            }
 
             // Short-circuit render if not editable
             if (!this.options.editable) {


### PR DESCRIPTION
Fix #685

Signed-off-by: Byron Ruth b@devel.io
