### PR TITLE
Rename default controls to be more descriptive

### DIFF
--- a/src/js/cilantro/config.js
+++ b/src/js/cilantro/config.js
@@ -88,14 +88,9 @@ define([
          * Keys represent the names of the controls and the value is either
          * a control class or a module name (that will be fetched on demand).
          *
-         * Built-in controls:
-         * - infograph: cilantro/ui/controls/infograph
-         * - number: cilantro/ui/controls/number
-         * - date: cilantro/ui/controls/date
-         * - search: cilantro/ui/controls/search
-         * - singleSelectionList: cilantro/ui/controls/select
-         * - multiSelectionList: cilantro/ui/controls/select
-         * - nullSelector: cilantro/ui/controls/null
+         * The default controls can be found near the top of:
+         *
+         *      cilantro/js/ui/controls/registry.js
          */
 
         controls: {},

--- a/src/js/cilantro/ui/controls/registry.js
+++ b/src/js/cilantro/ui/controls/registry.js
@@ -15,16 +15,40 @@ define([
 ], function(_, loglevel, c, date, number, search, select, infograph, nullSelector,
             text, vocab) {
 
+    /*
+     * TODO: Remove old keys(see list in below comment) for the 3.0 release as
+     * removing them during current renaming process is a breaking change. These
+     * key/value pairs should be removed in the 3.0 release:
+     *
+     *      infograph: infograph.InfographControl,
+     *      number: number.NumberControl,
+     *      date: date.DateControl,
+     *      search: search.SearchControl,
+     *      singleSelectionList: select.SingleSelectionList,
+     *      multiSelectionList: select.MultiSelectionList,
+     *      nullSelector: nullSelector.NullSelector,
+     *      text: text.TextControl,
+     *      vocab: vocab.VocabControl
+     */
     var defaultControls = {
         infograph: infograph.InfographControl,
+        infoBars: infograph.InfographControl,
         number: number.NumberControl,
+        numberRange: number.NumberControl,
         date: date.DateControl,
+        dateRange: date.DateControl,
         search: search.SearchControl,
+        valueSearch: search.SearchControl,
         singleSelectionList: select.SingleSelectionList,
+        singleValueSelect: select.SingleSelectionList,
         multiSelectionList: select.MultiSelectionList,
+        multiValueSelect: select.MultiSelectionList,
         nullSelector: nullSelector.NullSelector,
+        nullValueCheckbox: nullSelector.NullSelector,
         text: text.TextControl,
-        vocab: vocab.VocabControl
+        freeTextInput: text.TextControl,
+        vocab: vocab.VocabControl,
+        vocabSearch: vocab.VocabControl
     };
 
     var customControls = {};


### PR DESCRIPTION
Fix #430.

The original control names will be removed in the 3.0 release but remain here for backwards compatibility.

Signed-off-by: Don Naegely naegelyd@gmail.com
