### PR TITLE
Fix case where infograph was not highlighting selected filter values

### DIFF
--- a/src/js/cilantro/ui/controls/infograph.js
+++ b/src/js/cilantro/ui/controls/infograph.js
@@ -442,7 +442,7 @@ define ([
             var proxyFunc = function(method) {
                 _this[method] = function() {
                     var thisControl = _this.barsControl;
-                    return thisControl[method].call(thisControl, arguments);
+                    return thisControl[method].apply(thisControl, arguments);
                 };
 
                 return _this[method];


### PR DESCRIPTION
Fix #699.

The wrong method(call) was used when this was ported over from
CoffeeScript. Apply invokes the method with arguments in the form of an
array while call expects the full list of arguments so instead of
calling the proxy method with the full argument list, call was just
passing a single argument(itself a list of arguments) so the methods
were not being proxied correctly.

Signed-off-by: Don Naegely naegelyd@gmail.com
