### PR TITLE
Fix unstable event handler in workspace affecting save columns button

### DIFF
--- a/src/js/cilantro/ui/workflows/workspace.js
+++ b/src/js/cilantro/ui/workflows/workspace.js
@@ -62,10 +62,6 @@ define([
             this.on('router:unload', function() {
                 this.ui.loadingOverlay.hide();
             });
-
-            this.listenTo(this.data.view, 'request', function() {
-                this.ui.loadingOverlay.show();
-            });
         },
 
         onRender: function() {
@@ -118,6 +114,10 @@ define([
                 if (this.publicQueries) {
                     this.publicQueries.show(publicQueryView);
                 }
+            });
+
+            this.listenTo(this.data.view, 'request', function() {
+                this.ui.loadingOverlay.show();
             });
         }
     });


### PR DESCRIPTION
Fix #710.

This was an issue of where the event handler was initialized in the
workspace workflow. Formerly, the event handler was initialized in the
initialize method but the ui elements aren't initialized yet at that
point so we were trying to call 'show()' on a string(because ui elements
are string still during initialize). By setting the event handler in
onRender we can be sure that the ui elements have been initialized and
the event handler will be valid.

Signed-off-by: Don Naegely naegelyd@gmail.com
