### PR TITLE
Update selected columns when view is synced

### DIFF
--- a/src/js/cilantro/ui/concept/columns/dialog.js
+++ b/src/js/cilantro/ui/concept/columns/dialog.js
@@ -14,7 +14,7 @@ define([
 
         events: {
             'click [data-save]': 'save',
-            'click [data-dismiss]': 'cancel'
+            'click [data-dismiss]': 'reset'
         },
 
         ui: {
@@ -39,6 +39,15 @@ define([
             if (!(this.data.concepts = this.options.concepts)) {
                 throw new Error('concepts collection required');
             }
+
+            // Since the view can now be modified both here and by loading a
+            // shared query, we need to keep an ear out and listed for the sync
+            // event so we can reset the select/available columns. There is
+            // no risk of this affecting us post save because even though the
+            // sync event will happen after saving a new collection of selected
+            // columns, the reset will cause no changes in the UI because the
+            // synced result will be the view we just constructed.
+            this.listenTo(this.data.view, 'sync', this.reset);
         },
 
         onRender: function() {
@@ -57,7 +66,7 @@ define([
             this.body.show(this.columns);
         },
 
-        cancel: function() {
+        reset: function() {
             var _this = this;
 
             _.delay(function() {

--- a/src/js/cilantro/ui/concept/columns/layout.js
+++ b/src/js/cilantro/ui/concept/columns/layout.js
@@ -211,8 +211,8 @@ define([
             });
         },
 
-        // Maps the selected concepts to the exists facets collection. This ensures
-        // other attributes such as sort order are preserved.
+        // Maps the selected concepts to the exists facets collection. This
+        // ensures other attributes such as sort order are preserved.
         selectedToFacets: function() {
             var _this = this;
 

--- a/src/js/cilantro/ui/workflows/workspace.js
+++ b/src/js/cilantro/ui/workflows/workspace.js
@@ -51,6 +51,7 @@ define([
                 // Fully hide the panel; do not leave an edge to show/hide
                 c.panels.context.closePanel({full: true});
                 c.panels.concept.closePanel({full: true});
+                this.ui.loadingOverlay.hide();
             });
 
             // Query items, when clicked, will update the view and the context


### PR DESCRIPTION
Fix #712.

This fixes the case where a saved query is opened which has different columns than the current view. Then, the user opens the Change Columns modal and the columns there are different than those in the results table. Clicking Cancel then opening the dialog again fixed this. Now, the dialog will detect that sort of change and respond accordingly.

Signed-off-by: Don Naegely naegelyd@gmail.com
