### PR TITLE
Add silent option to value set calls to avoid revalidation per model

### DIFF
--- a/src/js/cilantro/models/value.js
+++ b/src/js/cilantro/models/value.js
@@ -70,10 +70,11 @@ define([
             // Nothing to check
             if (!models.length || !this.url) return;
 
-            // Mark the models as pending to prevent redundant validation
+            // Mark the models as pending to prevent redundant validation.
             _.each(models, function(model) {
-                model.set('pending', true);
+                model.set('pending', true, {silent: true});
             });
+            this.trigger('change');
 
             var _this = this;
 
@@ -86,7 +87,7 @@ define([
                     // Don't add since the value could have been removed
                     // in the meantime. Don't remove since this may only
                     // represent a subset of values in the collection.
-                    _this.set(resp, {add: false, remove: false});
+                    _this.set(resp, {add: false, remove: false, silent: true});
                 },
 
                 complete: function() {
@@ -94,8 +95,9 @@ define([
                     // has completed regardless if the request succeeded
                     // or failed.
                     _.each(models, function(model) {
-                        model.set('pending', false);
+                        model.set('pending', false, {silent: true});
                     });
+                    _this.trigger('change');
                 }
             });
         }


### PR DESCRIPTION
Fix #721.

Without this change, the validate method of the search control is
triggered for every single model because it listens to the events on the
collection. We now set everything silently and then, once the ajax call
is complete, trigger a change event that the search control will "hear"
and cause itself to revalidate.

Signed-off-by: Don Naegely naegelyd@gmail.com
