### PR TITLE
Silence set in search control setValue, trigger manual reset

### DIFF
--- a/src/js/cilantro/ui/controls/search.js
+++ b/src/js/cilantro/ui/controls/search.js
@@ -230,7 +230,8 @@ define([
         setValue: function(value) {
             // Do not merge into existing models since the collection contains
             // additional state (which would be removed due to the merge).
-            this.collection.set(value, {merge: false});
+            this.collection.set(value, {merge: false, silent: true});
+            this.collection.trigger('reset');
         },
 
         validate: function(attrs) {


### PR DESCRIPTION
Fix #723.

This fixes that case where setting the value was extremely slow for large lists of values. What was happening before was each value in the list was triggering an event and ui.values.reloadText() was being called(among other event handlers) due to all the events being generated per model during the set call. Now, the set call is silenced and then we manually trigger a reset.

Signed-off-by: Don Naegely naegelyd@gmail.com
