### PR TITLE
Fix timeout notification when ping returns redirect response

### DIFF
--- a/src/js/cilantro/session.js
+++ b/src/js/cilantro/session.js
@@ -103,7 +103,7 @@ define([
 
                     // Handle redirect
                     if (error === 'FOUND') {
-                        this.timeout(xhr.getResponseHeader('Location'));
+                        _this.timeout(xhr.getResponseHeader('Location'));
                     }
                 }
             });


### PR DESCRIPTION
Fix #728.

This fixes the issue where the call to `getResponseHeader` was causing a JS error and preventing the timeout notification from popping up. I am still unclear what was causing the problem in `getResponseHeader` since all I saw in the console was a generic `undefined is not a function` type error and then a partial stack trace into jquery code.

Signed-off-by: Don Naegely naegelyd@gmail.com
