### PR TITLE
Show filter text as user changes control values

### DIFF
--- a/src/js/cilantro/ui/controls/base.js
+++ b/src/js/cilantro/ui/controls/base.js
@@ -10,6 +10,19 @@ define([
 
     var noop = function() {};
 
+    var ControlLanguage = {
+        'in': ' is ',
+        '-in': ' not ',
+        'exact': ' is ',
+        'range': ' is between ',
+        '-range': ' is not between ',
+        'isnull': ' is ',
+        'gt': ' is greater than ',
+        'gte': ' is greater than or equal to ',
+        'lt': ' is less than ',
+        'lte': ' is less than or equal to '
+    };
+
     var ControlViewMixin = {
         className: 'control',
 
@@ -221,6 +234,7 @@ define([
         ControlCollectionView: ControlCollectionView,
         ControlCompositeView: ControlCompositeView,
         ControlLayout: ControlLayout,
+        ControlLanguage: ControlLanguage,
         Control: ControlLayout // backwards compatibility
     };
 

--- a/src/js/cilantro/ui/controls/infograph.js
+++ b/src/js/cilantro/ui/controls/infograph.js
@@ -413,11 +413,51 @@ define ([
         },
 
         ui: {
-            loading: '[data-target=loading-indicator]'
+            loading: '[data-target=loading-indicator]',
+            filterHelp: '.filter-help'
         },
 
         collectionEvents: {
-            'reset': 'toggleToolbar'
+            'reset': 'toggleToolbar',
+            'change': 'showFilterHelp'
+        },
+
+        showFilterHelp: function() {
+            var attrName = this.model.attributes.name;
+            var language = base.ControlLanguage;
+            var operator = language[this.barsControl.getOperator()];
+            var values = this.barsControl.getValue();
+
+            // Change all "" values to empty
+            for (var i = 0; i < values.length; i++) {
+                if (values[i].length === 0) {
+                    values[i] = 'empty';
+                }
+            }
+
+            var size = values.length;
+            var string = '';
+            var plural = ' either ',
+                preposition = ' or ';
+
+            if (operator === language['-in']) {
+                plural = ' neither ';
+                preposition = ' nor ';
+            }
+
+            if (size === 1) {
+                string = attrName + operator + ' ' + values[0];
+            }
+            else if (size === 2) {
+                string = attrName + plural + values[0] +
+                    preposition + values[1];
+            }
+            else if (size > 2) {
+                values[size - 1] = preposition + values[size - 1];
+                string = attrName + plural + values.join(', ');
+            }
+
+            this.ui.filterHelp.text(string);
         },
 
         initialize: function() {

--- a/src/js/cilantro/ui/controls/null.js
+++ b/src/js/cilantro/ui/controls/null.js
@@ -11,11 +11,23 @@ define([
         ui: {
             select: '[data-target=null-selector]',
             nullOption: '[data-target=null-option]',
-            notNullOption: '[data-target=not-null-option]'
+            notNullOption: '[data-target=not-null-option]',
+            filterHelp: '.filter-help'
         },
 
         events: {
-            'change [data-target=null-selector]': 'change'
+            'change [data-target=null-selector]': 'change',
+            'change': 'showFilterHelp'
+        },
+
+        showFilterHelp: function() {
+           var language = {
+                'true': ' is null',
+                'false': ' is not null'
+           };
+           var attrName = this.model.attributes.name;
+
+           this.ui.filterHelp.text(attrName + language[this.getValue()]);
         },
 
         initialize: function () {

--- a/src/js/cilantro/ui/controls/range.js
+++ b/src/js/cilantro/ui/controls/range.js
@@ -14,6 +14,7 @@ define([
         events: {
             'keyup .range-lower, .range-upper': '_change',
             'change .btn-select': '_change',
+            'change': 'showFilterHelp',
             'click .range-help-button': 'toggleHelpText'
         },
 
@@ -21,11 +22,42 @@ define([
             operatorSelect: '.btn-select',
             lowerBound: '.range-lower',
             upperBound: '.range-upper',
+            rangeHelper: '.range-helper',
             help: '.help-block'
         },
 
         initialize: function() {
             this._change = _.debounce(this.change, constants.INPUT_DELAY);
+            this.showFilterHelp = _.debounce(this.showFilterHelp,
+                constants.INPUT_DELAY);
+        },
+
+        showFilterHelp: function() {
+            var lower = this.ui.lowerBound.val();
+            var upper = this.ui.upperBound.val();
+
+            var language = base.ControlLanguage;
+
+            var operator = this.getOperator();
+
+            var attrName = this.model.attributes.name;
+
+            if (lower && upper) {
+                this.ui.rangeHelper.text(
+                        attrName + language[operator] +
+                        lower + ' and ' + upper);
+            }
+            else if (lower) {
+                this.ui.rangeHelper.text(
+                        attrName + language[operator]+ lower);
+            }
+            else if (upper) {
+                this.ui.rangeHelper.text(
+                        attrName + language[operator] + upper);
+            }
+            else {
+                this.ui.rangeHelper.text('');
+            }
         },
 
         onRender: function() {

--- a/src/js/cilantro/ui/controls/search.js
+++ b/src/js/cilantro/ui/controls/search.js
@@ -134,7 +134,9 @@ define([
 
         events: {
             'click [data-action=clear]': 'clearValues',
-            'change [name=exclude]': 'change'
+            'change [name=exclude]': 'showFilterHelpOnExclude',
+            'click .add-item-button': 'showFilterHelp',
+            'click .remove-item-button': 'showFilterHelp'
         },
 
         regions: {
@@ -152,7 +154,48 @@ define([
         },
 
         ui: {
-            excludeCheckbox: '[name=exclude]'
+            excludeCheckbox: '[name=exclude]',
+            filterHelp: '.filter-help'
+        },
+
+        showFilterHelpOnExclude: function() {
+            this.change();
+            this.showFilterHelp();
+        },
+
+        showFilterHelp: function() {
+            var attrName = this.model.attributes.name;
+            var language = controls.ControlLanguage;
+            var operator = language[this.getOperator()];
+            var values = _.pluck(this.getValue(), 'label');
+
+            var size = values.length;
+            var string = '';
+            var pluralOperator = ' either ',
+                preposition = ' or ';
+
+            if (operator === language['-in']) {
+                pluralOperator = ' neither ';
+                preposition = ' nor ';
+            }
+
+            if (size === 1) {
+                string = attrName + operator + ' ' + values[0];
+            }
+            else if (size === 2) {
+                string = attrName + pluralOperator + values[0] +
+                    preposition + values[1];
+            }
+            else if (size > 2) {
+                string = attrName + pluralOperator + values[0];
+                for (var i=1; i < size - 1; i++) {
+                    string += ',' + values[i];
+                }
+
+                string += preposition + values[size - 1];
+            }
+
+            this.ui.filterHelp.text(string);
         },
 
         initialize: function() {

--- a/src/js/cilantro/ui/controls/select.js
+++ b/src/js/cilantro/ui/controls/select.js
@@ -53,15 +53,36 @@ define([
         itemViewContainer: '.items',
 
         ui: {
-            items: '.items'
+            items: '.items',
+            filterHelp: '.filter-help'
         },
 
         events: {
-            'change .items': 'onSelectionChange'
+            'change .items': 'onSelectionChange',
+            'change': 'showFilterHelp'
         },
 
         collectionEvents: {
             'reset': 'onCollectionSync'
+        },
+
+        showFilterHelp: function() {
+            var attrName = this.model.attributes.name;
+            var language = base.ControlLanguage;
+            var operator = this.getOperator();
+
+            // Get the list of option elements in this item tag.
+            var options = this.ui.items.get(0);
+            var value = parseInt(this.getValue());
+
+            if (value !== 'NaN') {
+                var textVal = options[value - 1].text;
+                this.ui.filterHelp.text(attrName + language[operator] + textVal);
+            }
+            else {
+                value = this.getValue();
+                this.ui.filterHelp.text(attrName + language[operator] + value);
+            }
         },
 
         initialize: function() {

--- a/src/templates/controls/infograph/layout.html
+++ b/src/templates/controls/infograph/layout.html
@@ -1,5 +1,7 @@
-<div class=toolbar-region></div>
+<div class='toolbar-region'></div>
 <div data-target='loading-indicator'>
-    <i class="icon-spinner icon-spin"></i> Loading values...
+    <i class='icon-spinner icon-spin'></i> Loading values...
 </div>
-<div class=bars-region></div>
+<div class='bars-region'></div>
+<br>
+<span class='filter-help'></span>

--- a/src/templates/controls/null/layout.html
+++ b/src/templates/controls/null/layout.html
@@ -2,3 +2,5 @@
     <option data-target='not-null-option' value='false'>Exists</option>
     <option data-target='null-option' value='true'>Does not exist</option>
 </select>
+<br>
+<span class='filter-help' align='left'></span>

--- a/src/templates/controls/range/layout.html
+++ b/src/templates/controls/range/layout.html
@@ -1,5 +1,7 @@
-<input type=text class="range-lower" placeholder="[lower bound]" />
+<input type=text class='range-lower' placeholder='[lower bound]' />
 <span class=muted> and </span>
-<input type=text class="range-upper" placeholder="[upper bound]"/>
-<a class="btn range-help-button" href="#" title="Show/hide help text"><i class="icon-question-sign"></i></a>
-<span class="help-block">Entering a value on the left while leaving the right empty represents a filter matching all values greater than or equal to the supplied value. Conversely, entering a value on the right and leaving the left empty represents a filter matching all values less than or equal to the supplied value. Entering values in both boxes will match all values within the range specified. The opposite applies when <strong>not between</strong> is selected from the choices above.</span>
+<input type=text class='range-upper' placeholder='[upper bound]'/>
+<a class='btn range-help-button' href='#' title='Show/hide help text'><i class='icon-question-sign'></i></a>
+<span class='help-block'>Entering a value on the left while leaving the right empty represents a filter matching all values greater than or equal to the supplied value. Conversely, entering a value on the right and leaving the left empty represents a filter matching all values less than or equal to the supplied value. Entering values in both boxes will match all values within the range specified. The opposite applies when <strong>not between</strong> is selected from the choices above.</span>
+<br>
+<span class='range-helper' align='left'></span>

--- a/src/templates/controls/search/layout.html
+++ b/src/templates/controls/search/layout.html
@@ -15,5 +15,7 @@
             </button>
         </div>
         <div class=values-region></div>
+        <br>
+        <span class =filter-help></span>
    </div>
 </div>

--- a/src/templates/controls/select/list.html
+++ b/src/templates/controls/select/list.html
@@ -1,2 +1,4 @@
 <select class=items>
 </select>
+<br>
+<span class='filter-help' align='left'></span>


### PR DESCRIPTION
Fix #529 
single selection
![genotype](https://cloud.githubusercontent.com/assets/2774472/4864523/f813b95e-611c-11e4-934e-780c4dbfdfb5.png)
multi selection
![functclas](https://cloud.githubusercontent.com/assets/2774472/4864527/fd4e1e46-611c-11e4-91e2-9073f7c0bb2b.png)

null
![hgmd](https://cloud.githubusercontent.com/assets/2774472/4864535/0565a824-611d-11e4-9fec-b118702c8293.png)



The range one is left aligned as Don suggested.


Here is search
![cohort](https://cloud.githubusercontent.com/assets/2774472/5145494/32b58e70-7171-11e4-8763-de68905d5bee.png)


Here is infograph on openmrs
![sdgt](https://cloud.githubusercontent.com/assets/2774472/5145557/c618554e-7171-11e4-9dd5-f7e9d86de097.png)

The others are never used. 

Signed-off-by: Sheik Hassan <solergiga@yahoo.com>