### PR TITLE
Fix case where stats counts loader was not being hidden

### DIFF
--- a/src/js/cilantro/ui/stats.js
+++ b/src/js/cilantro/ui/stats.js
@@ -109,6 +109,12 @@ define([
             };
 
             this.collection.sort();
+        },
+
+        onRender: function() {
+            if (this.collection && this.collection.length > 0) {
+                this.hideLoader();
+            }
         }
     });
 


### PR DESCRIPTION
Fix #746.

This was occurring when navigating to the Workspace page via a navbar
link from the Query or Results page. This was happening because the code
that hid the loader used the 'ui' element which isn't available until
the Workspace is rendered so it won't work when the collection resets
and the Workspace page has not been shown yet. This fixes that case
without having to use raw jquery selectors to lookup the UI elements.

Signed-off-by: Don Naegely naegelyd@gmail.com
