### PR TITLE
Moved query item tool tips to the left.

### DIFF
--- a/src/js/cilantro/ui/query/item.js
+++ b/src/js/cilantro/ui/query/item.js
@@ -227,7 +227,7 @@ define([
             this.ui.publicIcon.tooltip({
                 html: true,
                 animation: false,
-                placement: 'right',
+                placement: 'left',
                 container: 'body'
             });
 
@@ -245,7 +245,7 @@ define([
                 this.ui.shareCount.tooltip({
                     html: true,
                     animation: false,
-                    placement: 'right',
+                    placement: 'left',
                     container: 'body'
                 });
             }


### PR DESCRIPTION
Fix #751 
![helo](https://cloud.githubusercontent.com/assets/2774472/5619079/a1df849c-94ec-11e4-85e5-09f078264ce8.png)

Signed-off-by: Sheik Hassan <solergiga@yahoo.com>