### PR TITLE
Fix typo in 'git clone' step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ The repository has a `.jshintrc` file that will enforce certain rules and conven
 
 ```bash
 # Clone the cilantro repo or a fork; go into the directory
-git clone git@github.com/chop-dbhi/cilantro.git && cd cilantro
+git clone git@github.com:chop-dbhi/cilantro.git && cd cilantro
 
 # Installs the dev depenencies including Grunt
 npm install


### PR DESCRIPTION
There is a minor typo in the `git clone` step to clone the Cilantro repo, this is just a small fix for it.