### PR TITLE
Add support for canceling on the results query and exports

### DIFF
--- a/src/js/cilantro/models/paginator.js
+++ b/src/js/cilantro/models/paginator.js
@@ -45,16 +45,18 @@ define([
                 });
             }
 
-            this.perPage = resp.per_page;   // jshint ignore:line
-            this.trigger('change:pagesize', this, this.perPage);
-            this.numPages = resp.num_pages; // jshint ignore:line
-            this.trigger('change:pagecount', this, this.numPages);
-            this.objectCount = resp.item_count;   // jshint ignore:line
-            this.trigger('change:objectcount', this, this.objectCount);
-            this.currentPageNum = null;
-            this.setCurrentPage(resp.page_num); // jshint ignore:line
+            if (resp) {
+                this.perPage = resp.per_page;   // jshint ignore:line
+                this.trigger('change:pagesize', this, this.perPage);
+                this.numPages = resp.num_pages; // jshint ignore:line
+                this.trigger('change:pagecount', this, this.numPages);
+                this.objectCount = resp.item_count;   // jshint ignore:line
+                this.trigger('change:objectcount', this, this.objectCount);
+                this.currentPageNum = null;
+                this.setCurrentPage(resp.page_num); // jshint ignore:line
 
-            return [resp];
+                return [resp];
+            }
         },
 
         // Ensures `num` is within the bounds

--- a/src/js/cilantro/models/results.js
+++ b/src/js/cilantro/models/results.js
@@ -2,11 +2,12 @@
 
 define([
     'underscore',
+    'backbone',
     '../core',
     '../constants',
     '../structs',
     './paginator'
-], function(_, c, constants, structs, paginator) {
+], function(_, Backbone, c, constants, structs, paginator) {
 
     var ResultsPage = structs.Frame.extend({
         idAttribute: 'page_num',
@@ -61,6 +62,21 @@ define([
         markAsDirty: function() {
             this.isDirty = true;
             this._refresh();
+        },
+
+        cancel: function() {
+            // Abort the request so handlers are not triggered.
+            if (this.pending) {
+                if (this.pending.abort) this.pending.abort();
+                delete this.pending;
+            }
+
+            // Send a DELETE request to the server to cancel the backend process.
+            return Backbone.ajax({
+                type: 'delete',
+                url: _.result(this, 'url'),
+                contentType: 'application/json'
+            });
         },
 
         fetch: function(options) {

--- a/src/js/cilantro/ui/exporter.js
+++ b/src/js/cilantro/ui/exporter.js
@@ -106,6 +106,13 @@ define([
 
             this.iframe.remove();
             this.model.set('status', 'canceled');
+
+            // Send DELETE request to cancel the backend processing.
+            $.ajax({
+                type: 'DELETE',
+                url: this.getExportUrl(),
+                contentType: 'application/json'
+            });
         },
 
         check: function() {
@@ -172,7 +179,6 @@ define([
                     break;
             }
 
-            this.ui.cancel.hide();
             this.ui.status.html(html);
             this.model.set('done', done);
         }

--- a/src/js/cilantro/ui/workflows/results.js
+++ b/src/js/cilantro/ui/workflows/results.js
@@ -64,14 +64,17 @@ define([
             navbar: '.results-workflow-navbar',
             resultsContainer: '.results-container',
             navbarButtons: '.results-workflow-navbar button',
-            loadingOverlay: '.loading-overlay'
+            loadingOverlay: '[data-target=results-loading-message]',
+            canceledQueryMessage: '[data-target=canceled-query-message]'
         },
 
         events: {
             'click [data-toggle=columns-dialog]': 'showColumnsDialog',
             'click [data-toggle=exporter-dialog]': 'showExporterDialog',
             'click [data-toggle=query-dialog]': 'showQueryDialog',
-            'click [data-toggle=context-panel]': 'toggleContextPanel'
+            'click [data-toggle=context-panel]': 'toggleContextPanel',
+            'click [data-action=cancel-query]': 'handleCancelQuery',
+            'click [data-action=retry-query]': 'handleRetryQuery'
         },
 
         regions: {
@@ -110,12 +113,41 @@ define([
             this.data.results.trigger('workspace:unload');
         },
 
+        handleCancelQuery: function(event) {
+            event.preventDefault();
+            this.data.results.cancel();
+            this.showCanceledQueryMessage();
+        },
+
+        handleRetryQuery: function(event) {
+            event.preventDefault();
+            // Hideous..
+            this.data.results.markAsDirty();
+            this.data.results.fetch();
+        },
+
+        showCanceledQueryMessage: function() {
+            this.hideLoadingOverlay();
+            this.ui.canceledQueryMessage.show();
+            this.table.$el.hide();
+        },
+
+        hideCanceledQueryMessage: function() {
+            this.ui.canceledQueryMessage.hide();
+            this.table.$el.show();
+        },
+
         showLoadingOverlay: function() {
-            if (this.isClosed !== true) this.ui.loadingOverlay.show();
+            if (this.isClosed !== true) {
+                this.hideCanceledQueryMessage();
+                this.ui.loadingOverlay.show();
+            }
         },
 
         hideLoadingOverlay: function() {
-            if (this.isClosed !== true) this.ui.loadingOverlay.hide();
+            if (this.isClosed !== true) {
+                this.ui.loadingOverlay.hide();
+            }
         },
 
         toggleContextPanel: function() {

--- a/src/scss/workflows/_base.scss
+++ b/src/scss/workflows/_base.scss
@@ -1,4 +1,4 @@
-.loading-overlay {
+.overlay {
     background: rgba(255, 255, 255, 0.7);
     position: absolute;
     top: 0;

--- a/src/templates/workflows/results.html
+++ b/src/templates/workflows/results.html
@@ -19,8 +19,23 @@
     </div>
 </div>
 
-<div class='loading-overlay hide'>
+<div class='overlay hide' data-target=results-loading-message>
     <h4><i class='icon-spinner icon-spin'></i> Loading Results</h4>
+
+    <p><em>Query taking too long?</em></p>
+    <button class='btn btn-default btn-lg' data-action='cancel-query'>Cancel Query</button>
+</div>
+
+<div class='hide' data-target='canceled-query-message'>
+    <h4>Query Canceled</h4>
+
+    <p>Some queries take more time than others to process. Here are two simple things you can try:</p>
+    <ul>
+        <li><strong>Reduce column variability.</strong> If the columns you've selected cross many domains, it takes longer to merge all that data together into results. Try removing <a data-toggle=columns-dialog href=#>one or two columns</a>.</li>
+        <li><strong>Increase specificity of filters.</strong> Adding filters increases the specificity of the query which decreases the number of possible results. This means there is less total data to process. Try <a data-route=query href=#>adding or changing a filter</a> to increase the specificity of the query.</li>
+    </ul>
+
+    <p>Want to retry the query? <button class='btn btn-primary' data-action=retry-query>Retry Query</button></p>
 </div>
 
 <div class=table-region></div>


### PR DESCRIPTION
When the loading overlap is shown, a button is now available to cancel
the query. This aborts the request and sends a DELETE request to the
endpoint to notify the server to stop processing of the results. Upon
canceling the query, a message is displayed with suggestions of how to
improve query if was taking too (and likely very complex).

Signed-off-by: Byron Ruth <b@devel.io>