### PR TITLE
WORK IN PROGRESS -- Add support for async requests

### DIFF
--- a/src/js/cilantro/config.js
+++ b/src/js/cilantro/config.js
@@ -17,7 +17,6 @@ define([
         // The selector of the element views will be rendered within.
         main: '#cilantro-main',
 
-
         /*
          * Sessions
          *
@@ -84,12 +83,19 @@ define([
          * concept names, operators and values to make filters more readable.
          */
         styleFilters: false,
-        
-        /* 
+
+        /*
         * Automatically refresh count statistics for context when filters
         * change.
         */
         distinctCountAutoRefresh: true,
+
+        /*
+         * When set to true, endpoints that support async requests will be
+         * used in an asynchronous fashion. When false, all endpoints will be
+         * used in their normal forms with blocking requests.
+         */
+        useAsyncRequests: false,
 
         /*
          * Timeouts

--- a/src/js/cilantro/models/exporter.js
+++ b/src/js/cilantro/models/exporter.js
@@ -2,8 +2,10 @@
 
 define([
     'underscore',
-    './base'
-], function(_, base) {
+    '../core',
+    '../utils',
+    './base',
+], function(_, c, utils, base) {
 
     var parseTitle = function(uri) {
         if (!uri) return 'Untitled';
@@ -36,6 +38,9 @@ define([
     });
 
 
+    var AsyncExporterCollection = base.Collection.extend({});
+
+
     var ExporterCollection = base.Collection.extend({
         model: ExporterModel,
 
@@ -57,8 +62,11 @@ define([
     });
 
     return {
-        ExporterModel: ExporterModel,
-        ExporterCollection: ExporterCollection
+        ExporterCollection: utils.chooseByRequestType(
+            AsyncExporterCollection,
+            ExporterCollection,
+            c.config.get('useAsyncRequests')
+        )
     };
 
 });

--- a/src/js/cilantro/models/results.js
+++ b/src/js/cilantro/models/results.js
@@ -6,8 +6,10 @@ define([
     '../core',
     '../constants',
     '../structs',
+    '../utils',
+    './base',
     './paginator'
-], function(_, Backbone, c, constants, structs, paginator) {
+], function(_, Backbone, c, constants, structs, utils, base, paginator) {
 
     var ResultsPage = structs.Frame.extend({
         idAttribute: 'page_num',
@@ -161,8 +163,14 @@ define([
     // Set the custom model for this Paginator.
     Results.prototype.model = ResultsPage;
 
+    var AsyncResults = base.Collection.extend({});
+
     return {
-        Results: Results
+        Results: utils.chooseByRequestType(
+            AsyncResults,
+            Results,
+            c.config.get('useAsyncRequests')
+       )
     };
 
 });

--- a/src/js/cilantro/ui/exporter.js
+++ b/src/js/cilantro/ui/exporter.js
@@ -5,9 +5,10 @@ define([
     'underscore',
     'backbone',
     'marionette',
+    '../utils',
     './base',
     './core'
-], function($, _, Backbone, Marionette, base, c) {
+], function($, _, Backbone, Marionette, utils, base, c) {
 
     var ExportOption = Marionette.ItemView.extend({
         tagName: 'label',
@@ -399,8 +400,14 @@ define([
         }
     });
 
+    var AsyncExporterDialog = Marionette.Layout.extend({});
+
     return {
-        ExporterDialog: ExporterDialog
+        ExporterDialog: utils.chooseByRequestType(
+            AsyncExporterDialog,
+            ExporterDialog,
+            c.config.get('useAsyncRequests')
+        )
     };
 
 });

--- a/src/js/cilantro/ui/workflows/results.js
+++ b/src/js/cilantro/ui/workflows/results.js
@@ -4,11 +4,12 @@ define([
     'jquery',
     'underscore',
     'marionette',
+    '../../utils',
     '../core',
     '../paginator',
     '../numbers',
     '../tables'
-], function($, _, Marionette, c, paginator, numbers, tables) {
+], function($, _, Marionette, utils, c, paginator, numbers, tables) {
 
 
     var ResultCount = Marionette.ItemView.extend({
@@ -295,8 +296,13 @@ define([
         }
     });
 
+    var AsyncResultsWorkflow = Marionette.Layout.extend({});
+
     return {
-        ResultCount: ResultCount,
-        ResultsWorkflow: ResultsWorkflow
+        ResultsWorkflow: utils.chooseByRequestType(
+            AsyncResultsWorkflow,
+            ResultsWorkflow,
+            c.config.get('useAsyncRequests')
+        )
     };
 });

--- a/src/js/cilantro/utils.js
+++ b/src/js/cilantro/utils.js
@@ -78,7 +78,21 @@ define([
         console.log(JSON.stringify(obj, null, 4));
     };
 
+    // Returns the supplied async or sync parameter based on the value
+    // of the supplied `useAsyncRequests` param. When `useAsyncRequests` is
+    // true, the async parameter will be returned. When it is false, the sync
+    // parameter is returned.
+    var chooseByRequestType = function(async, sync, useAsyncRequests) {
+        if (useAsyncRequests) {
+            return async;
+        }
+        else {
+            return sync;
+        }
+    };
+
     mods.unshift({
+        chooseByRequestType: chooseByRequestType,
         pprint: pprint,
         getDotProp: getDotProp,
         getCookie: getCookie,


### PR DESCRIPTION
@bruth 

I'm still working on the implementation of the async models and async UI elements so I just put stubs in here to keep the diff to a minimum for review. Wanted to get feedback on this approach for selecting different models and UI elements while I work on the async implementations themselves. 

More updates to follow but if you could take a look at this in the meantime, I'd like to get the approach for branching on request types locked in. Note, it assumes the presence of async endpoints as proposed in https://github.com/chop-dbhi/serrano/pull/284.  

Signed-off-by: Don Naegely <naegelyd@gmail.com>