### PR TITLE
Update Cilantro to work with Serrano 2.4

### DIFF
--- a/src/js/cilantro/main.js
+++ b/src/js/cilantro/main.js
@@ -96,6 +96,7 @@ require({
                 }),
 
                 results: new c.ui.ResultsWorkflow({
+                    context: this.data.contexts.session,
                     view: this.data.views.session,
                     // The differences in these names are noted
                     results: this.data.preview

--- a/src/js/cilantro/models/paginator.js
+++ b/src/js/cilantro/models/paginator.js
@@ -64,20 +64,6 @@ define([
             return (1 <= num && num <= this.numPages);
         },
 
-        // Checks the a _next_ page exists for num (or the current page)
-        hasNextPage: function(num) {
-            if (!num) num = this.currentPageNum;
-
-            return num < this.numPages;
-        },
-
-        // Checks the a _previous_ page exists for num (or the current page)
-        hasPreviousPage: function(num) {
-            if (!num) num = this.currentPageNum;
-
-            return num > 1;
-        },
-
         // Set the current page which triggers the 'change:page' event
         setCurrentPage: function(num) {
             if (num === this.currentPageNum) return;

--- a/src/js/cilantro/session.js
+++ b/src/js/cilantro/session.js
@@ -153,7 +153,13 @@ define([
             _.each(model.links, function(url, name) {
                 if ((Collection = collectionLinkMap[name])) {
                     this.data[name] = new Collection();
-                    this.data[name].url = url;
+                    // TODO: There should be a better way to do this, right?
+                    if (name === 'preview') {
+                        this.data[name]._url = url;
+                    }
+                    else {
+                        this.data[name].url = url;
+                    }
                     this.data[name].fetch({reset: true});
                 }
             }, this);

--- a/src/js/cilantro/ui/charts/utils.js
+++ b/src/js/cilantro/ui/charts/utils.js
@@ -13,7 +13,7 @@ define([
     var parseDate = function(str) {
         // Short-circut if the string is empty or if it does not conform to
         // the expected YYYY-MM-DD format.
-        if (!str || str.length != 10) return;
+        if (!str || str.length !== 10) return;
 
         var year = parseInt(str.substr(0, 4));
         var month = parseInt(str.substr(5, 2)) -1;

--- a/src/js/cilantro/ui/charts/utils.js
+++ b/src/js/cilantro/ui/charts/utils.js
@@ -11,6 +11,10 @@ define([
     };
 
     var parseDate = function(str) {
+        // Short-circut if the string is empty or if it does not conform to
+        // the expected YYYY-MM-DD format.
+        if (!str || str.length != 10) return;
+
         var year = parseInt(str.substr(0, 4));
         var month = parseInt(str.substr(5, 2)) -1;
         var day = parseInt(str.substr(8, 2));

--- a/src/js/cilantro/ui/numbers.js
+++ b/src/js/cilantro/ui/numbers.js
@@ -10,7 +10,7 @@ define([
     var renderCount = function($el, count, fallback) {
         if (!fallback) fallback = '<em>n/a</em>';
 
-        if (!count) {
+        if (count === null || count === undefined) {
             $el.html(fallback);
         }
         else {

--- a/src/js/cilantro/ui/tables/table.js
+++ b/src/js/cilantro/ui/tables/table.js
@@ -40,7 +40,7 @@ define([
             this.$el.append(this.header.el, this.footer.el);
 
             this.listenTo(this.collection, 'reset', function() {
-                if (this.collection.objectCount === 0) {
+                if (this.collection.numPages === 0) {
                     this.$el.hide();
                 }
                 else {


### PR DESCRIPTION
@bruth 

Fix https://github.com/chop-dbhi/cilantro/issues/744.

This PR updates Cilantro to work with Serrano 2.4. I tested this locally using a local instance of `harvest-openmrs`. Once we merge this, we can do a new release of Cilantro and I can update the Harvest OpenMRS demo repo with the new Cilantro and a couple other changes to make it Harvest 2.4 compatible.