### PR TITLE
Update count on render as well as context sync

### DIFF
--- a/src/js/cilantro/ui/workflows/results.js
+++ b/src/js/cilantro/ui/workflows/results.js
@@ -24,10 +24,11 @@ define([
         },
 
         initialize: function() {
-            this.model.stats.on('sync', this.onContextSynced, this);
+            this.model.stats.on('sync', this.updateCount, this);
+            this.on('render', this.updateCount, this)
         },
 
-        onContextSynced: function() {
+        updateCount: function() {
             var count = this.model.stats.get('count');
             this.collection.setResultCount(count);
             numbers.renderCount(


### PR DESCRIPTION
@bruth 

Fixes https://github.com/chop-dbhi/cilantro/issues/774.

This corrects a bug where the result count was not shown when the results pages was not the first page navigated to. This was caused by the removal of the onRender count updating in https://github.com/chop-dbhi/cilantro/pull/772. Previously, [the count was updated on render](https://github.com/chop-dbhi/cilantro/pull/772/files#diff-494269d91dfcf02d9a59db8d587bb8a4L30). This PR updates the `ResultCount` class to restore the update count on render behavior.

Signed-off-by: Don Naegely <naegelyd@gmail.com>