### PR TITLE
Replace null values with empty strings

### DIFF
--- a/src/js/cilantro/ui/charts/dist.js
+++ b/src/js/cilantro/ui/charts/dist.js
@@ -108,13 +108,16 @@ define([
             this.model.distribution(function(resp) {
                 if (_this.isClosed) return;
 
-                // Convert it into the structure the chart renderer expects
+                // Convert it into the structure the chart renderer expects.
+                // Since highcharts has odd behavior when encountering nul`
+                // we replace null values with empty strings to make the
+                // highcharts behavior more predictable.
                 var data = _.map(resp, function(item) {
                     return {
                         count: item.count,
                         values: [{
                             label: item.label,
-                            value: item.value
+                            value: item.value === null ? '' : item.value
                         }]
                     };
                 });


### PR DESCRIPTION
@bruth 

Fix https://github.com/chop-dbhi/cilantro/issues/773.

Highcharts behavior is very unpredictable when using null values in data points so we replace nulls with empty strings. For a more detailed explanation, see https://github.com/chop-dbhi/cilantro/issues/773#issuecomment-156868662.

Signed-off-by: Don Naegely <naegelyd@gmail.com>