### PR TITLE
Implement dialog for scripted API call

### DIFF
--- a/src/js/cilantro/main.js
+++ b/src/js/cilantro/main.js
@@ -67,7 +67,12 @@ require({
                     collection: this.data.queries
                 }),
 
-                deleteQuery: new c.ui.DeleteQueryDialog()
+                deleteQuery: new c.ui.DeleteQueryDialog(),
+
+                apiScript: new c.ui.ApiScriptDialog({
+                    view: this.data.views.session,
+                    context: this.data.contexts.session
+                })
             };
 
             var elements = [];

--- a/src/js/cilantro/ui.js
+++ b/src/js/cilantro/ui.js
@@ -12,6 +12,7 @@ define([
     './ui/context',
     './ui/controls',
     './ui/exporter',
+    './ui/api',
     './ui/field',
     './ui/notify',
     './ui/paginator',

--- a/src/js/cilantro/ui/api.js
+++ b/src/js/cilantro/ui/api.js
@@ -1,0 +1,129 @@
+/* global define */
+
+define([
+    'underscore',
+    'marionette',
+    '../core'
+], function(_, Marionette, c) {
+
+    // Remove extraneous attributes on the context nodes.
+    var stripContext = function(attrs) {
+      if (attrs.children) {
+        return {
+          type: attrs.type,
+          children: _.map(attrs.children, stripContext)
+        };
+      }
+
+      return {
+        concept: attrs.concept,
+        field: attrs.field,
+        operator: attrs.operator,
+        value: attrs.value
+      };
+    };
+
+    var ApiScriptDialog = Marionette.ItemView.extend({
+        className: 'modal hide',
+
+        template: 'api/dialog',
+
+        ui: {
+            // This is a faux pas to use IDs in a view selector,
+            // but Bootstrap requires them for the tab functionality.
+            curl: '#api-curl textarea',
+            python: '#api-python textarea',
+            type: 'input[name=type]'
+        },
+
+        events: {
+          'click @ui.type': 'changeType'
+        },
+
+        initialize: function() {
+            this.data = {};
+
+            if (!(this.data.context = this.options.context)) {
+                throw new Error('context model required');
+            }
+
+            if (!(this.data.view = this.options.view)) {
+                throw new Error('view model required');
+            }
+        },
+
+        onRender: function() {
+            var style = {
+              boxSizing: 'border-box',
+              width: '100%',
+              resize: 'none',
+              fontFamily: 'Monaco,Menlo,Consolas,"Courier New",monospace',
+              fontSize: '0.9em'
+            };
+
+            this.ui.curl.css(style);
+            this.ui.python.css(style);
+
+            this.$('.modal-body').css({
+              maxHeight: '600px'
+            });
+
+            this.$el.css({
+                bottom: '10%'
+            }).modal({
+                show: false,
+                keyboard: false,
+                backdrop: 'static'
+            });
+        },
+
+        open: function() {
+            this.$el.modal('show');
+            this.renderSnippets();
+        },
+
+        close: function() {
+            this.$el.modal('hide');
+        },
+
+        changeType: function() {
+          this.renderSnippets();
+        },
+
+        renderSnippets: function() {
+            // Prepare body of POST request using the current context and view.
+            var body = JSON.stringify({
+              context: stripContext(this.data.context.get('json')),
+              view: this.data.view.get('json')
+            });
+
+            // Escape single quotes in the JSON string since it will be embedded in a
+            // single quoted string in the target language.
+            body = body.replace("'", "\\'");
+
+            var type = this.ui.type.filter(':checked').val();
+
+            // Get the URI for the JSON exporter.
+            var url = c.data.exporter.get(type).get('uri');
+
+            var ctx = {
+              url: url,
+              body: body,
+              type: type,
+              token: 'YOUR-TOKEN-HERE'
+            };
+
+            // Render the templates.
+            var curl = c.templates.get('api/curl')(ctx);
+            var python = c.templates.get('api/python')(ctx);
+
+            // Fill the textareas.
+            this.ui.curl.val(curl);
+            this.ui.python.val(python);
+        }
+    });
+
+    return {
+        ApiScriptDialog: ApiScriptDialog
+    };
+});

--- a/src/js/cilantro/ui/templates.js
+++ b/src/js/cilantro/ui/templates.js
@@ -4,6 +4,10 @@ define([
     'underscore',
     'loglevel',
 
+    'tpl!templates/api/dialog.html',
+    'tpl!templates/api/curl.txt',
+    'tpl!templates/api/python.txt',
+
     'tpl!templates/count.html',
     'tpl!templates/notification.html',
     'tpl!templates/paginator.html',
@@ -113,7 +117,7 @@ define([
         name = name.replace(/\.\.\//g, '');
 
         // Remove templates prefix, strip extension
-        return name.replace(/templates\//, '').replace(/\.html$/, '');
+        return name.replace(/templates\//, '').replace(/\.\w+$/, '');
     };
 
     // Registers all built-in templates using the augmented _moduleName from

--- a/src/js/cilantro/ui/workflows/results.js
+++ b/src/js/cilantro/ui/workflows/results.js
@@ -109,6 +109,7 @@ define([
             'click [data-toggle=columns-dialog]': 'showColumnsDialog',
             'click [data-toggle=exporter-dialog]': 'showExporterDialog',
             'click [data-toggle=query-dialog]': 'showQueryDialog',
+            'click [data-toggle=api-script-dialog]': 'showApiScriptDialog',
             'click [data-toggle=context-panel]': 'toggleContextPanel',
             'click [data-action=cancel-query]': 'handleCancelQuery',
             'click [data-action=retry-query]': 'handleRetryQuery'
@@ -334,6 +335,10 @@ define([
             // Opens the query modal without passing a model which assumes a
             // new one will be created based on the current session.
             c.dialogs.query.open();
+        },
+
+        showApiScriptDialog: function() {
+          c.dialogs.apiScript.open();
         }
     });
 

--- a/src/templates/api/curl.txt
+++ b/src/templates/api/curl.txt
@@ -1,0 +1,4 @@
+curl -L -X POST <%= data.url %> \
+    -H "Content-Type: application/json" \
+    -H "Api-Token: <%= data.token %>" \
+    -d '<%= data.body %>'

--- a/src/templates/api/dialog.html
+++ b/src/templates/api/dialog.html
@@ -1,0 +1,39 @@
+<div class=modal-header>
+    <a class=close data-dismiss=modal><i class="icon-remove"></i></a>
+    <h3>API Script</h3>
+</div>
+
+<div class=modal-body>
+    <div class="alert alert-info">
+      <strong>Note:</strong> API access requires a token. Ask the site maintainer to generate one for you. Replace the <code>YOUR-TOKEN-HERE</code> variable with your token.
+    </div>
+
+    <p>Script or program to execute the current query and dump the results as JSON or CSV.</p>
+
+    <form>
+      <label class="radio inline">
+        <input type="radio" name="type" value="json" checked> JSON
+      </label>
+
+      <label class="radio inline">
+        <input type="radio" name="type" value="csv"> CSV
+      </label>
+    </form>
+
+    <ul class="nav nav-tabs">
+      <li class="active"><a href="#api-curl" data-toggle="tab">cURL</a></li>
+      <li><a href="#api-python" data-toggle="tab">Python</a></li>
+    </ul>
+
+    <div class="tab-content">
+      <div class="tab-pane active" id="api-curl">
+        <p>
+        <textarea rows="10"></textarea>
+      </div>
+
+      <div class="tab-pane" id="api-python">
+        <p>This code requires the <a href="http://docs.python-requests.org/" target="_blank">requests</a> library.</p>
+        <textarea rows="10"></textarea>
+      </div>
+    </div>
+</div>

--- a/src/templates/api/python.txt
+++ b/src/templates/api/python.txt
@@ -1,0 +1,21 @@
+import requests
+
+# Required headers for the request.
+headers = {
+  'Content-Type': 'application/json',
+  'Api-Token': '<%= data.token %>'
+}
+
+# Body encoded as JSON.
+body = '<%= data.body %>'
+
+# Send the POST request.
+resp = requests.post('<%= data.url %>',
+                     headers=headers,
+                     data=body)
+
+# Raise exception for 4xx or 5xx status codes.
+resp.raise_for_status()
+
+<% if (data.type === 'json') { %># Decode JSON response.
+data = resp.json()<% } %>

--- a/src/templates/workflows/results.html
+++ b/src/templates/workflows/results.html
@@ -11,6 +11,9 @@
             <button data-toggle=query-dialog class='btn btn-primary btn-mini' title='Save/Share Query'>
                 <i class=icon-save></i> <span class=large-display-button-text>Save/Share Query...</span>
             </button>
+            <button data-toggle=api-script-dialog class='btn btn-primary btn-mini' title='API Script'>
+                <i class=icon-code></i> <span class=large-display-button-text>API Script...</span>
+            </button>
             <button data-toggle=context-panel class='btn btn-primary btn-mini expand-collapse' title='Hide Filter Panel'>
                 <i class=icon-expand-alt></i> <span class=large-display-button-text>Hide Filters</span>
             </button>


### PR DESCRIPTION
The motivation for this change is to provide a starting pointing for
writing scripts to export results based on query developed in the
interface.

The change introduces a new dialog containing pre-fabricated API
calls using cURL and the Python requests library for JSON or CSV
formats. The dialog can be opened using a new button in the results
toolbar.

Fix #777

Signed-off-by: Byron Ruth <b@devel.io>