### PR TITLE
Include native CSRF support

### DIFF
--- a/src/js/cilantro/config.js
+++ b/src/js/cilantro/config.js
@@ -37,6 +37,12 @@ define([
             }
         },
 
+        csrf: {
+            header: 'X-CSRFToken',
+            // Included to support a legacy pattern.
+            token: window.csrfToken || window.csrf_token  // jshint ignore:line
+        },
+
         // Convenience option: URL of the default session
         url: null,
 
@@ -84,8 +90,8 @@ define([
          * concept names, operators and values to make filters more readable.
          */
         styleFilters: false,
-        
-        /* 
+
+        /*
         * Automatically refresh count statistics for context when filters
         * change.
         */

--- a/src/js/cilantro/csrf.js
+++ b/src/js/cilantro/csrf.js
@@ -1,0 +1,31 @@
+/* global define */
+
+define([
+  'jquery'
+], function($) {
+
+    function sameOrigin(url) {
+        var host = document.location.host,
+            protocol = document.location.protocol,
+            srOrigin = '//' + host,
+            origin = protocol + srOrigin;
+
+        return (url === origin || url.slice(0, origin.length + 1) === origin + '/') || (url === srOrigin || url.slice(0, srOrigin.length + 1) === srOrigin + '/') || !(/^(\/\/|http:|https:).*/.test(url));     // jshint ignore:line
+    }
+
+    function safeMethod(method) {
+        return /^(GET|HEAD|OPTIONS|TRACE)$/.test(method);
+    }
+
+    function apply(header, token) {
+        $.ajaxPrefilter(function(settings, origSettings, xhr) {
+            if (!safeMethod(settings.type) && sameOrigin(settings.url)) {
+                return xhr.setRequestHeader(header, token);
+            }
+        });
+    }
+
+    return {
+        apply: apply
+    };
+});

--- a/src/js/cilantro/setup.js
+++ b/src/js/cilantro/setup.js
@@ -7,8 +7,9 @@ define([
     'jquery',
     'loglevel',
     './core',
-    './ui'
-], function(_, Backbone, Marionette, $, loglevel, c, ui) {
+    './ui',
+    './csrf',
+], function(_, Backbone, Marionette, $, loglevel, c, ui, csrf) {
 
     // Set configuration options for corresponding APIs
     c.templates.set(c.config.get('templates', {}));
@@ -55,6 +56,12 @@ define([
             withCredentials: true
         };
     });
+
+    // Apply CSRF hooks if enabled.
+    var csrfConfig = c.config.get('csrf');
+    if (csrfConfig && csrfConfig.token) {
+        csrf.apply(csrfConfig.header, csrfConfig.token);
+    }
 
     // Setup debugging facilities
     if (c.config.get('debug')) {


### PR DESCRIPTION
By default, this uses the X-CSRFToken header and the includes the global
csrfToken or csrf_token variable. This is done for historical reasons.

Fix #770

Signed-off-by: Byron Ruth <b@devel.io>