### PR TITLE
Added option to either display the field on lower case or as it was defined

### DIFF
--- a/src/js/cilantro/config.js
+++ b/src/js/cilantro/config.js
@@ -213,7 +213,22 @@ define([
 
         // Option to show button in the search layout to remove
         // invalid objects
-        showRemoveInvalidButton: true
+        showRemoveInvalidButton: true,
+
+        /*
+         * Vocab
+         *
+         *  - fieldNameDisplay: define a function to change the format of the
+         *    names displayed. Returns an object containing {single, plural} names
+         */
+        vocab: {
+            fieldNameDisplay: function(names) {
+                return {
+                  single: names.single.toLowerCase() || '',
+                  plural: names.plural.toLowerCase() || ''
+                };
+            }
+        }
     };
 
 

--- a/src/js/cilantro/ui/controls/vocab.js
+++ b/src/js/cilantro/ui/controls/vocab.js
@@ -11,8 +11,9 @@ define([
     '../values',
     '../paginator',
     '../../models',
+    '../../core',
 ], function($, _, Backbone, Marionette, controls, searchControl, search, values,
-            paginator, models) {
+            paginator, models, c) {
 
 
     // Collection that listens to another collection for models that match
@@ -156,8 +157,16 @@ define([
     // available operator.
     var BucketList = Marionette.View.extend({
         initialize: function() {
-            var name = this.model.get('alt_name').toLowerCase(),
-                pluralName = this.model.get('alt_plural_name').toLowerCase();
+            var name = this.model.get('alt_name'),
+                pluralName = this.model.get('alt_plural_name'),
+                vocabConfig = c.config.get('vocab');
+
+            if (typeof vocabConfig.fieldNameDisplay === 'function') {
+                var names = {single: name, plural: pluralName},
+                    displayNames = vocabConfig.fieldNameDisplay(names);
+                name = displayNames.single;
+                pluralName  = displayNames.plural;
+            }
 
             this.buckets = [{
                 name: 'At least one ' + name + ' must match',


### PR DESCRIPTION
Context:
We had a request to change one the modules behavior: vocab. 
Vocab has a component, called bucket and within this component the name of the field that was selected is displayed. The thing is that one the fields contains a name, Fyler, thus it should not be lower cased. 

Solution:
I added an option to let the field not be lower cased. 